### PR TITLE
Bumped Python version to 3.6

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -1,8 +1,8 @@
 import click
 from subprocess import check_call
 
-DEFAULT_PYTHON_VERSION = "3.5"
-PYTHON_VERSIONS = ["3.5"]
+DEFAULT_PYTHON_VERSION = "3.6"
+PYTHON_VERSIONS = ["3.6"]
 
 ADDITIONAL_CORE_DEPS = [
 ]


### PR DESCRIPTION
Requires the corresponding PR to force_bdss to be pulled before this will pass.