### PR TITLE
[WIP] Custom plots added to both plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
     - edm install -y --version 3.5 click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
+    - git clone --branch feature/custom_dataview git://github.com/force-h2020/force-wfmanager.git
+    - pushd force-wfmanager && edm run -- python -m ci install && popd
 script:
     - edm run -- python -m ci install
     - edm run -- python -m ci flake8

--- a/eggbox_potential_sampler/eggbox_pes_data_source/data_source.py
+++ b/eggbox_potential_sampler/eggbox_pes_data_source/data_source.py
@@ -73,9 +73,9 @@ class EggboxPESDataSource(BaseDataSource):
         ----------
         trial: numpy.ndarray
             (N, ) array containing the trial position.
-        basin_positions: list
+        basin_positions: numpy.ndarray
             (M, N) array containing the positions of each of the M basins.
-        basin_depths: list
+        basin_depths: numpy.ndarray
             (M, ) array containing the depth of each basin.
 
         Returns

--- a/eggbox_potential_sampler/eggbox_plugin.py
+++ b/eggbox_potential_sampler/eggbox_plugin.py
@@ -2,6 +2,7 @@ from force_bdss.api import BaseExtensionPlugin, plugin_id
 
 from .eggbox_pes_data_source.factory import EggboxPESDataSourceFactory
 from .random_sampling_mco.mco_factory import RandomSamplingMCOFactory
+from .sampling_data_view import SamplingDataViewPane
 
 PLUGIN_VERSION = 0
 
@@ -35,4 +36,9 @@ class EggboxPlugin(BaseExtensionPlugin):
         return [
             EggboxPESDataSourceFactory,
             RandomSamplingMCOFactory
+        ]
+
+    def get_data_views(self):
+        return [
+            SamplingDataViewPane
         ]

--- a/eggbox_potential_sampler/sampling_data_view/__init__.py
+++ b/eggbox_potential_sampler/sampling_data_view/__init__.py
@@ -1,0 +1,1 @@
+from .sampling_data_view import SamplingDataViewPane

--- a/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
+++ b/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
@@ -95,19 +95,24 @@ class ConvergencePlot(BasePlot):
 
         """
         try:
-            min_y = 1.1 * min(self._custom_data_array)
+            min_y = min(self._custom_data_array) - 0.1
         except ValueError:
             min_y = -0.1
         try:
-            max_y = 1.1 * max(self._custom_data_array)
+            max_y = max(self._custom_data_array) + 0.1
         except ValueError:
             max_y = 1
-        try:
-            max_x = len(self._custom_data_array) + 1
-        except Exception:
-            max_x = 1
 
-        ranges = (0, max_x, min_y, max_y)
+        try:
+            max_x = 1.1 * len(self._custom_data_array)
+        except ValueError:
+            max_x = 1
+        try:
+            min_x = -0.1 * len(self._custom_data_array) + 1
+        except ValueError:
+            min_x = 0
+
+        ranges = (min_x, max_x, min_y, max_y)
         self._set_plot_range(*ranges)
 
         for idx, overlay in enumerate(self._plot.overlays):

--- a/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
+++ b/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
@@ -1,0 +1,139 @@
+from traits.api import on_trait_change, List, Instance, Enum
+from traitsui.api import View, VGroup, HGroup, Item, UItem
+from enable.api import ComponentEditor
+from chaco.tools.api import PanTool, ZoomTool
+
+from force_wfmanager.central_pane.data_view_pane import DataViewPane
+from force_wfmanager.central_pane.plot import Plot
+from force_wfmanager.central_pane.plot import BasePlot, ChacoPlot
+
+
+class ConvergencePlot(BasePlot):
+    """ This is an example of a more complicated plot that could be
+    contributed by a plug-in.
+
+    Here, the running minimum of the y-values is displayed on a line
+    plot.
+
+    """
+
+    #: Simple re-labelling of the underlying :class:`BasePlot` trait.
+    y = Enum(values='_value_names', label='convergence variable')
+
+    #: Extra array to hold our custom plot data
+    _custom_data_array = List()
+
+    #: The View of the plot, showing the menu to choose 'y' and the plot itself
+    view = View(
+        VGroup(
+            HGroup(
+                Item('y'),
+            ),
+            UItem('_plot', editor=ComponentEditor())
+        )
+    )
+
+    def plot_cumulative_line(self):
+        """ Create the Chaco line plot. """
+        plot = ChacoPlot(self._plot_data)
+        line_plot = plot.plot(
+            ('iteration', 'cumulative_minimum'),
+            type='line',
+            name='Line plot',
+            marker='circle',
+            bgcolor='white')[0]
+
+        line_plot.tools.append(PanTool(plot))
+        line_plot.overlays.append(ZoomTool(plot))
+
+        self._plot_index_datasource = line_plot.index
+        plot.set(title=self.title, padding=75, line_width=1)
+        self._axis = line_plot
+
+        return plot
+
+    @on_trait_change('x,y')
+    def _update_plot_data(self):
+        """ Override update_plot_data to include the new ancillary
+        array.
+
+        """
+        super()._update_plot_data()
+        self._custom_data_array = []
+
+        if self.y is None:
+            return
+
+        y_index = self.analysis_model.value_names.index(self.y)
+        for ind, _ in enumerate(self._data_arrays[y_index], start=1):
+            self._custom_data_array.append(
+                min(self._data_arrays[y_index][:ind]))
+        self._plot_data.set_data('cumulative_minimum',
+                                 self._custom_data_array)
+        self._plot_data.set_data(
+            'iteration',
+            list(range(1, len(self._custom_data_array) + 1))
+        )
+
+        self.resize_plot()
+
+    def __plot_default(self):
+        """ Set the new default plot. """
+        self._plot = self.plot_cumulative_line()
+        return self._plot
+
+    def __plot_data_default(self):
+        """ Add custom columns to the default plot data. """
+        plot_data = self._get_plot_data_default()
+        plot_data.set_data('cumulative_minimum', [])
+        plot_data.set_data('iteration', [])
+        return plot_data
+
+    def resize_plot(self):
+        """ Override resize plot based on the data we're actually
+        plotting.
+
+        """
+        try:
+            min_y = 1.1 * min(self._custom_data_array)
+        except ValueError:
+            min_y = -0.1
+        try:
+            max_y = 1.1 * max(self._custom_data_array)
+        except ValueError:
+            max_y = 1
+        try:
+            max_x = len(self._custom_data_array) + 1
+        except Exception:
+            max_x = 1
+
+        ranges = (0, max_x, min_y, max_y)
+        self._set_plot_range(*ranges)
+
+        for idx, overlay in enumerate(self._plot.overlays):
+            if isinstance(overlay, ZoomTool):
+                self._plot.overlays[idx] = ZoomTool(self._plot)
+
+        return ranges
+
+
+class SamplingDataViewPane(DataViewPane):
+    """ This :class:`DataViewPane` shows two plot types side-by-side. """
+
+    name = 'Potential Sampling Data View'
+
+    colormap_plot = Instance(Plot)
+    sampling_plot = Instance(ConvergencePlot)
+
+    traits_view = View(
+        HGroup(UItem('colormap_plot', style='custom'),
+               UItem('sampling_plot', style='custom')))
+
+    def _colormap_plot_default(self):
+        return Plot(analysis_model=self.analysis_model,
+                    title='Potential energy surface',
+                    color_plot=True)
+
+    def _sampling_plot_default(self):
+        return ConvergencePlot(analysis_model=self.analysis_model,
+                               title='Convergence')

--- a/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
+++ b/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
@@ -10,7 +10,7 @@ from force_wfmanager.central_pane.plot import BasePlot, ChacoPlot
 
 class ConvergencePlot(BasePlot):
     """ This is an example of a more complicated plot that could be
-    contributed by a plug-in.
+    contributed by a plugin.
 
     Here, the running minimum of the y-values is displayed on a line
     plot.
@@ -55,7 +55,7 @@ class ConvergencePlot(BasePlot):
     @on_trait_change('x,y')
     def _update_plot_data(self):
         """ Override update_plot_data to include the new ancillary
-        array.
+        array, and an array containing the index of that array.
 
         """
         super()._update_plot_data()

--- a/enthought_example/example_data_views/__init__.py
+++ b/enthought_example/example_data_views/__init__.py
@@ -1,0 +1,1 @@
+from .example_data_view import ExampleDataViewPane

--- a/enthought_example/example_data_views/example_data_view.py
+++ b/enthought_example/example_data_views/example_data_view.py
@@ -1,0 +1,45 @@
+from force_wfmanager.central_pane.plot import BasePlot, ChacoPlot
+from force_wfmanager.central_pane.data_view_pane import DataViewPane
+from traits.api import Instance
+from traitsui.api import View, HGroup, UItem
+
+
+class ExampleCustomPlot(BasePlot):
+    """ This is an example of a custom plot, that replaces
+    the default scatter plot with a line plot.
+
+    """
+
+    title = 'Example line plot'
+
+    def plot_line(self):
+        plot = ChacoPlot(self._plot_data)
+        line_plot = plot.plot(
+            ('x', 'y'),
+            type='line',
+            name='Line plot',
+            marker='circle',
+            bgcolor='white')[0]
+
+        self._plot_index_datasource = line_plot.index
+        self._axis = line_plot
+        plot.set(title=self.title)
+
+        return plot
+
+    def __plot_default(self):
+        self._plot = self.plot_line()
+        return self._plot
+
+
+class ExampleDataViewPane(DataViewPane):
+
+    name = 'Example Data View Pane'
+
+    line_plot = Instance(ExampleCustomPlot)
+
+    traits_view = View(
+        HGroup(UItem('line_plot', style='custom')))
+
+    def _line_plot_default(self):
+        return ExampleCustomPlot(analysis_model=self.analysis_model)

--- a/enthought_example/example_plugin.py
+++ b/enthought_example/example_plugin.py
@@ -4,6 +4,7 @@ from .example_notification_listener import ExampleNotificationListenerFactory
 from .example_mco import ExampleMCOFactory
 from .example_data_source import ExampleDataSourceFactory
 from .example_ui_hooks import ExampleUIHooksFactory
+from .example_data_views import ExampleDataViewPane
 
 PLUGIN_VERSION = 0
 
@@ -51,5 +52,8 @@ class ExamplePlugin(BaseExtensionPlugin):
             ExampleDataSourceFactory,
             ExampleMCOFactory,
             ExampleNotificationListenerFactory,
-            ExampleUIHooksFactory
+            ExampleUIHooksFactory,
         ]
+
+    def get_data_views(self):
+        return [ExampleDataViewPane]


### PR DESCRIPTION
This PR adds custom DataViewPane examples for each plugin.

- Adds a simple line plot to the PowerSourceEvaluator MCO.
- Adds a "Sampling View" to the RandomSamplingMCO, which does a colourmap of the potential energy surface and a cumulative track of the current minimum sampled value.