### PR TITLE
Updated scipy to 1.2.1

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -5,7 +5,7 @@ DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
 
 ADDITIONAL_CORE_DEPS = [
-    'scipy>=1.0.0'
+    'scipy>=1.2.1'
 ]
 
 


### PR DESCRIPTION
The scipy 1.0.0-3 package we were using is broken on windows (but not macOS or Linux somehow!). Luckily there is a later version available which does work on all platforms