### PR TITLE
Updates to travis CI: handle X connection on Linux; add macOs worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,46 @@
-language: c
-cache:
-  directories:
-      - "$HOME/.cache"
-      - "$HOME/.ccache"
+language: generic
+sudo: false
+
+env:
+  global:
+    - EDM_FULL=1.11.0
+      EDM_X_Y=1.11
+
+matrix:
+  include:
+  - os: linux
+    dist: bionic
+    services:
+      - xvfb
+    env: 
+      - EDM_OS="rh5_x86_64"
+        EDM_INSTALLER_SUFFIX="_linux_x86_64.sh"
+  - os: osx
+    env:
+      - EDM_OS="osx_x86_64"
+        EDM_INSTALLER_SUFFIX=".pkg"
+
 before_install:
-    - ccache -s
-    - export PATH=/usr/lib/ccache:${PATH}
-    - wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
-    - export PATH=${HOME}/edm/bin:${PATH}
-    - edm install -y --version 3.5 click setuptools
+    - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX}
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -b -f -p $HOME ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "osx" ]] ; then sudo installer -pkg ./edm_${EDM_FULL}${EDM_INSTALLER_SUFFIX} -target / ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
+    - edm install -y --version 3.6 click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
+    - git clone --branch feature/custom_dataview git://github.com/force-h2020/force-wfmanager.git
+    - pushd force-wfmanager && edm run -- python -m ci install && popd
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:
     - edm run -- python -m ci install
     - edm run -- python -m ci flake8
+    - export ETS_TOOLKIT=qt4
+    - export DISPLAY=:99.0
     - edm run -- python -m ci test
     - edm run -- python -m ci docs
 after_success:
-    - edm run -- python -m ci coverage
-    - edm run -- pip install codecov
-    - edm run -- codecov
-    - bash <(curl -s https://codecov.io/bash)
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then edm run -- python -m ci coverage; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then edm run -- pip install codecov; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then edm run -- codecov; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ before_install:
     - edm install -y --version 3.6 click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
-    - git clone --branch feature/custom_dataview git://github.com/force-h2020/force-wfmanager.git
-    - pushd force-wfmanager && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:
     - edm run -- python -m ci install

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_install:
 script:
     - edm run -- python -m ci install
     - edm run -- python -m ci flake8
-    - export ETS_TOOLKIT=qt4
     - export DISPLAY=:99.0
     - edm run -- python -m ci test
     - edm run -- python -m ci docs

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -25,7 +25,7 @@ sphinx.environment.BuildEnvironment.warn_node = _warn_node
 def mock_modules():
     import sys
 
-    from mock import MagicMock
+    from unittest.mock import MagicMock
 
     class Mock(MagicMock):
         @classmethod


### PR DESCRIPTION
* X handling: 
  similar to https://github.com/force-h2020/force-wfmanager/pull/284.
  Follows an update of the Travis Linux VM defaults.

* macOS worker
  similar to https://github.com/force-h2020/force-wfmanager/pull/297

A broken import of `mock` was fixed (or `ci docs` would error)