### PR TITLE
Custom UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+*.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
     - edm install -y --version 3.6 click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
-    - git clone git://github.com/force-h2020/force-wfmanager.git -b enh/refactor-custom-ui
+    - git clone git://github.com/force-h2020/force-wfmanager.git
     - pushd force-wfmanager && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
     - edm install -y --version 3.6 click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
-    - git clone git://github.com/force-h2020/force-wfmanager.git
+    - git clone git://github.com/force-h2020/force-wfmanager.git -b enh/refactor-custom-ui
     - pushd force-wfmanager && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:

--- a/enthought_example/example_contributed_ui/__init__.py
+++ b/enthought_example/example_contributed_ui/__init__.py
@@ -1,0 +1,1 @@
+from .example_contributed_ui import ExampleContributedUI  # noqa

--- a/enthought_example/example_contributed_ui/example_contributed_ui.py
+++ b/enthought_example/example_contributed_ui/example_contributed_ui.py
@@ -1,7 +1,7 @@
 from traits.api import Float, Int, Property, on_trait_change
 from traitsui.api import Group, Heading, Item
 
-from force_wfmanager.ui.contributed_ui.contributed_ui import ContributedUI
+from force_wfmanager.ui import ContributedUI
 
 _ENTHOUGHT_PLUGIN_ID = "force.bdss.enthought.plugin.example.v0.factory"
 

--- a/enthought_example/example_contributed_ui/example_contributed_ui.py
+++ b/enthought_example/example_contributed_ui/example_contributed_ui.py
@@ -1,0 +1,133 @@
+from traits.api import Float, Int, Property, on_trait_change
+from traitsui.api import Group, Heading, Item
+
+from force_wfmanager.ui.contributed_ui.contributed_ui import ContributedUI
+
+_ENTHOUGHT_PLUGIN_ID = "force.bdss.enthought.plugin.example.v0.factory"
+
+
+class ExampleContributedUI(ContributedUI):
+    #: Name for the UI in selection screen
+    name = "Example Workflow"
+
+    #: Description of the UI
+    desc = (
+        "A simplified UI which allows the selection of a range and exponent"
+    )
+
+    #: Traits for settings in the UI
+    lower = Int(1)
+    upper = Int(9)
+    power = Float(3.0)
+    initial_value = Property(Float, depends_on='lower,upper')
+
+    def _workflow_data_default(self):
+        return self.workflow_data_update()
+
+    @on_trait_change('lower,upper,power')
+    def workflow_data_update(self):
+        wf_data = {
+            "mco": self._mco_data(),
+            "execution_layers": self._execution_layer_data(),
+            "notification_listeners":  self._notification_listener_data()
+        }
+        self.workflow_data = wf_data
+        return wf_data
+
+    def _get_initial_value(self):
+        return (self.lower + self.upper) / 2.0
+
+    def _workflow_group_default(self):
+        workflow_group = Group(
+            Heading("Power Example Settings"),
+            Item("lower", label="Lower bound"),
+            Item("upper", label="Upper bound"),
+            Item("power", label="Exponent"),
+        )
+        return workflow_group
+
+    def _mco_data(self):
+        return {
+            "id": '.'.join([_ENTHOUGHT_PLUGIN_ID, "example_mco"]),
+            "model_data": {
+                "parameters": [
+                    {
+                        "id": ".".join([
+                            _ENTHOUGHT_PLUGIN_ID, "example_mco",
+                            "parameter", "ranged"
+                        ]),
+                        "model_data": {
+                            "lower_bound": self.lower,
+                            "upper_bound": self.upper,
+                            "initial_value": self.initial_value,
+                            "name": "input_number",
+                            "type": "number"
+                        }
+                    }
+                ],
+                "kpis": [
+                    {"name": "input_number_sq", "objective": "MINIMISE"},
+                    {"name": "input_number_8", "objective": "MAXIMISE"}
+                ],
+            }
+        }
+
+    def _execution_layer_data(self):
+        return [
+            [
+                {
+                    "id": ".".join([
+                        _ENTHOUGHT_PLUGIN_ID, "example_data_source"
+                    ]),
+                    "model_data": {
+                        "power": self.power,
+                        "cuba_type_in": "number",
+                        "cuba_type_out": "number_sq",
+                        "input_slot_info": [
+                            {
+                                "source": "Environment",
+                                "name": "input_number"
+                            }
+                        ],
+                        "output_slot_info": [
+                            {
+                                "name": "input_number_sq"
+                            }
+                        ]
+                    }
+                }
+            ],
+            [
+                {
+                    "id": ".".join([
+                        _ENTHOUGHT_PLUGIN_ID, "example_data_source"
+                    ]),
+                    "model_data": {
+                        "power": 4.0,
+                        "cuba_type_in": "number_sq",
+                        "cuba_type_out": "number_8",
+                        "input_slot_info": [
+                            {
+                                "source": "Environment",
+                                "name": "input_number_sq"
+                            }
+                        ],
+                        "output_slot_info": [
+                            {
+                                "name": "input_number_8"
+                            }
+                        ]
+                    }
+                }
+            ]
+        ]
+
+    def _notification_listener_data(self):
+        return [
+                {
+                    "id": ".".join([
+                        _ENTHOUGHT_PLUGIN_ID, "example_notification_listener"
+                        ]),
+                    "model_data": {}
+                }
+            ]

--- a/enthought_example/example_contributed_ui/tests/test_example_contributed_ui.py
+++ b/enthought_example/example_contributed_ui/tests/test_example_contributed_ui.py
@@ -1,0 +1,62 @@
+import unittest
+
+from traitsui.api import Group
+
+try:
+    # It's possible to install the example plugins in a headless system or
+    # in a environment without wfmanager and the graphical stack for UIs.
+    #
+    # This module depends on UIs so won't be tested in this case.
+    from enthought_example.example_contributed_ui\
+        .example_contributed_ui import ExampleContributedUI
+except ModuleNotFoundError:
+    raise unittest.SkipTest(
+        "No wfmanager found in the test environment. "
+        "Contributed UIs can't be tested."
+    )
+
+
+class TestExampleContributedUI(unittest.TestCase):
+
+    def setUp(self):
+        self.custom_ui = ExampleContributedUI()
+
+    def test___init__(self):
+
+        self.assertIsNotNone(self.custom_ui.workflow_data)
+        self.assertIsNotNone(self.custom_ui.workflow_group)
+        self.assertIsInstance(self.custom_ui.workflow_group, Group)
+        self.assertEqual(5, self.custom_ui.initial_value)
+
+    def test_initial_value(self):
+        self.custom_ui.lower = 0
+        self.assertEqual(4.5, self.custom_ui.initial_value)
+        self.custom_ui.upper = 10
+        self.assertEqual(5, self.custom_ui.initial_value)
+
+    def test_mco_data(self):
+
+        mco_data = self.custom_ui._mco_data()
+        keys = list(mco_data.keys())
+
+        self.assertListEqual(['id', 'model_data'], keys)
+
+    def test_execution_layer_data(self):
+
+        execution_layer_data = self.custom_ui._execution_layer_data()
+        self.assertEqual(2, len(execution_layer_data))
+
+        for execution_layer in execution_layer_data:
+            for data_source in execution_layer:
+                keys = list(data_source.keys())
+                self.assertListEqual(['id', 'model_data'], keys)
+
+    def test_notification_listener_data(self):
+
+        notification_listener_data = (
+            self.custom_ui._notification_listener_data()
+        )
+        self.assertEqual(1, len(notification_listener_data))
+
+        keys = list(notification_listener_data[0].keys())
+        self.assertListEqual(['id', 'model_data'], keys)

--- a/enthought_example/example_data_views/example_data_view.py
+++ b/enthought_example/example_data_views/example_data_view.py
@@ -24,7 +24,7 @@ class ExampleCustomPlot(BasePlot):
 
         self._plot_index_datasource = line_plot.index
         self._axis = line_plot
-        plot.set(title=self.title)
+        plot.trait_set(title=self.title)
 
         return plot
 

--- a/enthought_example/example_plugin.py
+++ b/enthought_example/example_plugin.py
@@ -56,7 +56,7 @@ class ExamplePlugin(UIExtensionPlugin):
             ExampleUIHooksFactory
         ]
 
-    def get_contributed_UIs(self):
+    def get_contributed_uis(self):
         return [
-            ExampleContributedUI()
+            ExampleContributedUI
         ]

--- a/enthought_example/example_plugin.py
+++ b/enthought_example/example_plugin.py
@@ -1,5 +1,6 @@
 from force_bdss.api import plugin_id
-from force_bdss.core_plugins.service_offers_plugin import ServiceOffersPlugin
+from force_bdss.core_plugins.service_offer_plugin import \
+    ServiceOfferExtensionPlugin
 
 from .example_notification_listener import ExampleNotificationListenerFactory
 from .example_mco import ExampleMCOFactory
@@ -10,7 +11,7 @@ from .example_ui_hooks import ExampleUIHooksFactory
 PLUGIN_VERSION = 0
 
 
-class ExamplePlugin(ServiceOffersPlugin):
+class ExamplePlugin(ServiceOfferExtensionPlugin):
     """This is an example of the plugin system for the BDSS.
     This class provides access points for the various entities
     that the plugin system supports:

--- a/enthought_example/example_plugin.py
+++ b/enthought_example/example_plugin.py
@@ -1,4 +1,5 @@
-from force_bdss.api import BaseExtensionPlugin, plugin_id
+from force_bdss.api import plugin_id
+from force_bdss.core_plugins.service_offers_plugin import ServiceOffersPlugin
 
 from .example_notification_listener import ExampleNotificationListenerFactory
 from .example_mco import ExampleMCOFactory
@@ -9,7 +10,7 @@ from .example_ui_hooks import ExampleUIHooksFactory
 PLUGIN_VERSION = 0
 
 
-class ExamplePlugin(BaseExtensionPlugin):
+class ExamplePlugin(ServiceOffersPlugin):
     """This is an example of the plugin system for the BDSS.
     This class provides access points for the various entities
     that the plugin system supports:
@@ -62,10 +63,26 @@ class ExamplePlugin(BaseExtensionPlugin):
         """Get any ContributedUI classes included in the plugin"""
         from enthought_example.example_contributed_ui\
             .example_contributed_ui import ExampleContributedUI
+
         return [ExampleContributedUI]
 
     def get_data_views(self):
         """Get any BasePlot classes included in the plugin"""
         from enthought_example.example_data_views.example_data_view import \
             ExampleCustomPlot
+
         return [ExampleCustomPlot]
+
+    def get_service_offer_factories(self):
+        """Overloaded method of ServiceOffersPlugin class used to define service_offers
+        trait"""
+        from force_wfmanager.ui import IContributedUI
+        from force_wfmanager.ui import IDataView
+
+        contributed_uis = self.get_contributed_uis()
+        data_views = self.get_data_views()
+
+        return [
+            (IContributedUI, contributed_uis),
+            (IDataView, data_views)
+        ]

--- a/enthought_example/example_plugin.py
+++ b/enthought_example/example_plugin.py
@@ -1,14 +1,16 @@
-from force_bdss.api import BaseExtensionPlugin, plugin_id
+from force_bdss.api import plugin_id
+from force_wfmanager.ui import UIExtensionPlugin
 
 from .example_notification_listener import ExampleNotificationListenerFactory
 from .example_mco import ExampleMCOFactory
 from .example_data_source import ExampleDataSourceFactory
 from .example_ui_hooks import ExampleUIHooksFactory
+from .example_contributed_ui import ExampleContributedUI
 
 PLUGIN_VERSION = 0
 
 
-class ExamplePlugin(BaseExtensionPlugin):
+class ExamplePlugin(UIExtensionPlugin):
     """This is an example of the plugin system for the BDSS.
     This class provides access points for the various entities
     that the plugin system supports:
@@ -52,4 +54,9 @@ class ExamplePlugin(BaseExtensionPlugin):
             ExampleMCOFactory,
             ExampleNotificationListenerFactory,
             ExampleUIHooksFactory
+        ]
+
+    def get_contributed_UIs(self):
+        return [
+            ExampleContributedUI()
         ]

--- a/enthought_example/example_plugin.py
+++ b/enthought_example/example_plugin.py
@@ -75,11 +75,12 @@ class ExamplePlugin(ServiceOfferExtensionPlugin):
         return [ExampleCustomPlot]
 
     def get_service_offer_factories(self):
-        """Overloaded method of ServiceOffersPlugin class used to define service_offers
-        trait. In this example, we import 2 types of custom UI objects using the
-        Interfaces for ContributedUI and DataView classes, found in force-wfmanager.
-        The methods get_contributed_uis and get_data_views return the example
-        UI subclasses provided by this plugin"""
+        """Overloaded method of ServiceOffersPlugin class used to define
+        service_offers trait. In this example, we import 2 types of custom UI
+        objects using the Interfaces for ContributedUI and DataView classes,
+        found in force-wfmanager. The methods get_contributed_uis and
+        get_data_views return the example UI subclasses provided by this
+        plugin"""
         from force_wfmanager.ui import IContributedUI
         from force_wfmanager.ui import IDataView
 

--- a/enthought_example/example_plugin.py
+++ b/enthought_example/example_plugin.py
@@ -59,7 +59,7 @@ class ExamplePlugin(ServiceOfferExtensionPlugin):
 
     # The following functionalities are optional (the plugin can be run on the
     # bdss without a GUI), so the quite expensive imports are done
-    # inside eac method.
+    # inside each method.
     def get_contributed_uis(self):
         """Get any ContributedUI classes included in the plugin"""
         from enthought_example.example_contributed_ui\
@@ -76,7 +76,10 @@ class ExamplePlugin(ServiceOfferExtensionPlugin):
 
     def get_service_offer_factories(self):
         """Overloaded method of ServiceOffersPlugin class used to define service_offers
-        trait"""
+        trait. In this example, we import 2 types of custom UI objects using the
+        Interfaces for ContributedUI and DataView classes, found in force-wfmanager.
+        The methods get_contributed_uis and get_data_views return the example
+        UI subclasses provided by this plugin"""
         from force_wfmanager.ui import IContributedUI
         from force_wfmanager.ui import IDataView
 

--- a/enthought_example/example_plugin.py
+++ b/enthought_example/example_plugin.py
@@ -1,16 +1,15 @@
-from force_bdss.api import plugin_id
-from force_wfmanager.ui import UIExtensionPlugin
+from force_bdss.api import BaseExtensionPlugin, plugin_id
 
 from .example_notification_listener import ExampleNotificationListenerFactory
 from .example_mco import ExampleMCOFactory
 from .example_data_source import ExampleDataSourceFactory
 from .example_ui_hooks import ExampleUIHooksFactory
-from .example_contributed_ui import ExampleContributedUI
+
 
 PLUGIN_VERSION = 0
 
 
-class ExamplePlugin(UIExtensionPlugin):
+class ExamplePlugin(BaseExtensionPlugin):
     """This is an example of the plugin system for the BDSS.
     This class provides access points for the various entities
     that the plugin system supports:
@@ -56,15 +55,17 @@ class ExamplePlugin(UIExtensionPlugin):
             ExampleUIHooksFactory,
         ]
 
+    # The following functionalities are optional (the plugin can be run on the
+    # bdss without a GUI), so the quite expensive imports are done
+    # inside eac method.
     def get_contributed_uis(self):
-        return [
-            ExampleContributedUI
-        ]
+        """Get any ContributedUI classes included in the plugin"""
+        from enthought_example.example_contributed_ui\
+            .example_contributed_ui import ExampleContributedUI
+        return [ExampleContributedUI]
 
     def get_data_views(self):
-        # This functionality is optional (the plugin can be run on the
-        # bdss without a GUI), so this quite expensive import is done
-        # inside the method.
+        """Get any BasePlot classes included in the plugin"""
         from enthought_example.example_data_views.example_data_view import \
             ExampleCustomPlot
         return [ExampleCustomPlot]

--- a/enthought_example/tests/test_example_plugin.py
+++ b/enthought_example/tests/test_example_plugin.py
@@ -21,10 +21,10 @@ from enthought_example.tests import example_workflows
 class TestExamplePlugin(unittest.TestCase):
     def test_basic_functionality(self):
         plugin = ExamplePlugin()
-        self.assertEqual(len(plugin.data_source_factories), 1)
-        self.assertEqual(len(plugin.mco_factories), 1)
-        self.assertEqual(len(plugin.notification_listener_factories), 1)
-        self.assertEqual(len(plugin.ui_hooks_factories), 1)
+        self.assertEqual(1, len(plugin.data_source_factories))
+        self.assertEqual(1, len(plugin.mco_factories))
+        self.assertEqual(1, len(plugin.notification_listener_factories))
+        self.assertEqual(1, len(plugin.ui_hooks_factories))
 
     @unittest.skipIf(
         not WFMANAGER_AVAILABLE,
@@ -32,7 +32,7 @@ class TestExamplePlugin(unittest.TestCase):
     def test_get_data_views(self):
         plugin = ExamplePlugin()
         plots = plugin.get_data_views()
-        self.assertEqual(len(plots), 1)
+        self.assertEqual(1, len(plots))
         for plot in plots:
             self.assertIsInstance(plot, type)
             self.assertTrue(issubclass(plot, BaseDataView))
@@ -43,10 +43,23 @@ class TestExamplePlugin(unittest.TestCase):
     def test_get_contributed_uis(self):
         plugin = ExamplePlugin()
         custom_uis = plugin.get_contributed_uis()
-        self.assertEqual(len(custom_uis), 1)
+        self.assertEqual(1, len(custom_uis))
         for custom_ui in custom_uis:
             self.assertIsInstance(custom_ui, type)
             self.assertTrue(issubclass(custom_ui, ContributedUI))
+
+    @unittest.skipIf(
+        not WFMANAGER_AVAILABLE,
+        "No wfmanager found in the test environment. Skipping test.")
+    def test_get_service_offer_factories(self):
+        plugin = ExamplePlugin()
+        service_offer_factories = plugin.get_service_offer_factories()
+        self.assertEqual(2, len(service_offer_factories))
+
+        interface, factories = service_offer_factories[0]
+        self.assertEqual(IContributedUI, interface)
+        interface, factories = service_offer_factories[1]
+        self.assertEqual(IDataView, interface)
 
 
 class TestExamplePluginIntegration(unittest.TestCase):

--- a/enthought_example/tests/test_example_plugin.py
+++ b/enthought_example/tests/test_example_plugin.py
@@ -79,3 +79,20 @@ class TestExamplePluginIntegration(unittest.TestCase):
             BDSSApplication(True, self.empty_workflow_path)
         except ModuleNotFoundError:
             self.fail("Has BDSS attempted to import .example_data_views?")
+
+    def test_contributed_ui_module_not_imported_by_bdss(self):
+        # hide the get_contributed_uis module
+        sys.modules[
+            "enthought_example.example_contributed_ui.example_contributed_ui"
+        ] = None
+
+        plugin = ExamplePlugin()
+        # accessing get_contributed_uis should trigger the import (and fail)
+        with self.assertRaises(ModuleNotFoundError):
+            plugin.get_contributed_uis()
+
+        # However, BDSS shouldn't attempt the import
+        try:
+            BDSSApplication(True, self.empty_workflow_path)
+        except ModuleNotFoundError:
+            self.fail("Has BDSS attempted to import .example_contributed_ui?")

--- a/enthought_example/tests/test_example_plugin.py
+++ b/enthought_example/tests/test_example_plugin.py
@@ -7,7 +7,8 @@ try:
     # It's possible to install the example plugins in a headless system or
     # in a environment without wfmanager and the graphical stack for UIs.
     # Some tests will be skipped.
-    from force_wfmanager.ui.review.data_view import BaseDataView
+    from force_wfmanager.ui import BaseDataView
+    from force_wfmanager.ui import ContributedUI
 except ModuleNotFoundError:
     WFMANAGER_AVAILABLE = False
 else:
@@ -35,6 +36,17 @@ class TestExamplePlugin(unittest.TestCase):
         for plot in plots:
             self.assertIsInstance(plot, type)
             self.assertTrue(issubclass(plot, BaseDataView))
+
+    @unittest.skipIf(
+        not WFMANAGER_AVAILABLE,
+        "No wfmanager found in the test environment. Skipping test.")
+    def test_get_contributed_uis(self):
+        plugin = ExamplePlugin()
+        custom_uis = plugin.get_contributed_uis()
+        self.assertEqual(len(custom_uis), 1)
+        for custom_ui in custom_uis:
+            self.assertIsInstance(custom_ui, type)
+            self.assertTrue(issubclass(custom_ui, ContributedUI))
 
 
 class TestExamplePluginIntegration(unittest.TestCase):

--- a/enthought_example/tests/test_example_plugin.py
+++ b/enthought_example/tests/test_example_plugin.py
@@ -7,8 +7,8 @@ try:
     # It's possible to install the example plugins in a headless system or
     # in a environment without wfmanager and the graphical stack for UIs.
     # Some tests will be skipped.
-    from force_wfmanager.ui import BaseDataView
-    from force_wfmanager.ui import ContributedUI
+    from force_wfmanager.ui import BaseDataView, IDataView
+    from force_wfmanager.ui import ContributedUI, IContributedUI
 except ModuleNotFoundError:
     WFMANAGER_AVAILABLE = False
 else:


### PR DESCRIPTION
This provides a small UI allowing a user to set the min, max and exponent for a power series example. At present it works with most of the json specification for the workflow "in code", which is not too pleasant to look at.
I tested having these UIs come from workflow files and it is a lot more flexible, but also potentially quite fragile so there's a choice to be made there.

UPDATE:

This PR now requires additional functionalities from the `force-bdss` `ServiceOfferExtensionPlugin` class, introduced in force-h2020/force-bdss#228

It also requires updates from `force-wfmanager` PRs https://github.com/force-h2020/force-wfmanager/pull/324 and force-h2020/force-wfmanager#328 in order to pass unit testing