### PR TITLE
Fixes to missed updates after Refactor BDSS Application

### DIFF
--- a/eggbox_potential_sampler/random_sampling_mco/mco.py
+++ b/eggbox_potential_sampler/random_sampling_mco/mco.py
@@ -32,14 +32,14 @@ class RandomSamplingMCO(BaseMCO):
 
         """
         kpis = model.kpis
-        application = self.factory.plugin.application
+        workflow_file = self.factory.plugin.application.workflow_file
         if model.evaluation_mode == "Subprocess":
             single_point_evaluator = SubprocessSinglePointEvaluator(
-                sys.argv[0], application.workflow_file.path
+                sys.argv[0], workflow_file.path
             )
         else:
             single_point_evaluator = InternalSinglePointEvaluator(
-                application.workflow_file.workflow,
+                workflow_file.workflow,
                 model.parameters
             )
 

--- a/eggbox_potential_sampler/random_sampling_mco/mco.py
+++ b/eggbox_potential_sampler/random_sampling_mco/mco.py
@@ -35,11 +35,11 @@ class RandomSamplingMCO(BaseMCO):
         application = self.factory.plugin.application
         if model.evaluation_mode == "Subprocess":
             single_point_evaluator = SubprocessSinglePointEvaluator(
-                sys.argv[0], application.workflow_filepath
+                sys.argv[0], application.workflow_file.path
             )
         else:
             single_point_evaluator = InternalSinglePointEvaluator(
-                application.workflow,
+                application.workflow_file.workflow,
                 model.parameters
             )
 

--- a/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco.py
+++ b/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco.py
@@ -58,7 +58,8 @@ class TestRandomSamplingMCO(unittest.TestCase):
         model.parameters = [DummyMCOParameter(
             mock.Mock(spec=DummyMCOParameterFactory))]
 
-        with mock.patch('force_bdss.api.Workflow.execute') as mock_exec:
-            mock_exec.return_value = [DataValue(value=1), DataValue(value=2)]
+        kpis = [DataValue(value=1), DataValue(value=2)]
+        with mock.patch('force_bdss.api.Workflow.execute',
+                        return_value=kpis) as mock_exec:
             opt.run(model)
             self.assertEqual(mock_exec.call_count, 7)

--- a/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco.py
+++ b/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco.py
@@ -2,32 +2,40 @@ import unittest
 
 from unittest import mock
 
-from force_bdss.api import BaseMCOFactory, DataValue, Workflow
+from envisage.plugin import Plugin
+from force_bdss.api import DataValue, Workflow
+from force_bdss.app.workflow_file import WorkflowFile
 
 from eggbox_potential_sampler.random_sampling_mco.parameters import (
     DummyMCOParameter, DummyMCOParameterFactory)
 
-from eggbox_potential_sampler.random_sampling_mco.mco_model import (
-    RandomSamplingMCOModel)
 from eggbox_potential_sampler.random_sampling_mco.mco import (
     RandomSamplingMCO)
+from eggbox_potential_sampler.random_sampling_mco.mco_factory import (
+    RandomSamplingMCOFactory)
+
+
+def probe_execute(*args, **kwargs):
+    return [DataValue(value=1), DataValue(value=2)]
 
 
 class TestRandomSamplingMCO(unittest.TestCase):
     def setUp(self):
-        self.factory = mock.Mock(spec=BaseMCOFactory)
-        self.factory.plugin = mock.Mock()
+        self.plugin = mock.Mock(spec=Plugin, id="pid")
+        self.factory = RandomSamplingMCOFactory(self.plugin)
         self.factory.plugin.application = mock.Mock()
-        self.factory.plugin.application.workflow_filepath = "whatever"
-        self.factory.plugin.application.workflow = mock.Mock(spec=Workflow)
+        self.factory.plugin.application.workflow_file = mock.Mock(
+            spec=WorkflowFile, path="whatever",
+            workflow=Workflow()
+        )
 
     def test_initialization(self):
         opt = RandomSamplingMCO(self.factory)
         self.assertEqual(opt.factory, self.factory)
 
     def test_subprocess_run(self):
-        opt = RandomSamplingMCO(self.factory, )
-        model = RandomSamplingMCOModel(self.factory)
+        opt = self.factory.create_optimizer()
+        model = self.factory.create_model()
         model.num_trials = 7
         model.evaluation_mode = 'Subprocess'
         model.parameters = [DummyMCOParameter(
@@ -43,16 +51,14 @@ class TestRandomSamplingMCO(unittest.TestCase):
         self.assertEqual(mock_popen.call_count, 7)
 
     def test_internal_run(self):
-        opt = RandomSamplingMCO(self.factory, )
-        model = RandomSamplingMCOModel(self.factory)
+        opt = self.factory.create_optimizer()
+        model = self.factory.create_model()
         model.num_trials = 7
         model.evaluation_mode = 'Internal'
         model.parameters = [DummyMCOParameter(
             mock.Mock(spec=DummyMCOParameterFactory))]
 
-        self.factory.plugin.application.workflow = Workflow()
-        kpis = [DataValue(value=1), DataValue(value=2)]
-        with mock.patch('force_bdss.api.Workflow.execute',
-                        return_value=kpis) as mock_exec:
+        with mock.patch('force_bdss.api.Workflow.execute') as mock_exec:
+            mock_exec.return_value = [DataValue(value=1), DataValue(value=2)]
             opt.run(model)
             self.assertEqual(mock_exec.call_count, 7)

--- a/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
+++ b/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
@@ -47,7 +47,7 @@ class ConvergencePlot(BasePlot):
         line_plot.overlays.append(ZoomTool(plot))
 
         self._plot_index_datasource = line_plot.index
-        plot.set(title=self.title, padding=75, line_width=1)
+        plot.trait_set(title=self.title, padding=75, line_width=1)
         self._axis = line_plot
 
         return plot

--- a/enthought_example/example_mco/example_mco.py
+++ b/enthought_example/example_mco/example_mco.py
@@ -88,7 +88,7 @@ class ExampleMCO(BaseMCO):
             # MCOCommunicator. NOTE: The communicator is involved in the
             # communication between the MCO executable and the bdss single
             # point evaluation, _not_ between the bdss and the MCO executable.
-            cmd = [sys.argv[0], "--evaluate", application.workflow_filepath]
+            cmd = [sys.argv[0], "--evaluate", application.workflow_file.path]
             ps = subprocess.Popen(
                 cmd, env=env, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
 

--- a/enthought_example/example_mco/example_mco.py
+++ b/enthought_example/example_mco/example_mco.py
@@ -74,7 +74,7 @@ class ExampleMCO(BaseMCO):
 
         value_iterator = itertools.product(*values)
 
-        application = self.factory.plugin.application
+        workflow_file = self.factory.plugin.application.workflow_file
 
         for value in value_iterator:
             # Setting ETS_TOOLKIT=null before executing bdss prevents it
@@ -88,7 +88,7 @@ class ExampleMCO(BaseMCO):
             # MCOCommunicator. NOTE: The communicator is involved in the
             # communication between the MCO executable and the bdss single
             # point evaluation, _not_ between the bdss and the MCO executable.
-            cmd = [sys.argv[0], "--evaluate", application.workflow_file.path]
+            cmd = [sys.argv[0], "--evaluate", workflow_file.path]
             ps = subprocess.Popen(
                 cmd, env=env, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
 

--- a/enthought_example/example_mco/tests/test_example_mco.py
+++ b/enthought_example/example_mco/tests/test_example_mco.py
@@ -3,7 +3,8 @@ import unittest
 from unittest import mock
 from traits.api import TraitError
 
-from force_bdss.api import BaseMCOFactory
+from force_bdss.api import BaseMCOFactory, Workflow
+from force_bdss.app.workflow_file import WorkflowFile
 
 from enthought_example.example_mco.parameters import (
     RangedMCOParameter,
@@ -19,7 +20,10 @@ class TestExampleMCO(unittest.TestCase):
         self.factory = mock.Mock(spec=BaseMCOFactory)
         self.factory.plugin = mock.Mock()
         self.factory.plugin.application = mock.Mock()
-        self.factory.plugin.application.workflow_filepath = "whatever"
+        self.factory.plugin.application.workflow_file = mock.Mock(
+            spec=WorkflowFile, path="whatever",
+            workflow=Workflow()
+        )
 
     def test_initialization(self):
         opt = ExampleMCO(self.factory)


### PR DESCRIPTION
PR #31 missed a few crucial updates that were not picked up by existing unit tests.

Specifically:
- Removing the need for Envisage plugins to instantiate `BaseFactory` subclasses in unit tests
- Including new `WorkflowFile` class in unit tests
- Replacing `application.workflow` references to `application.workflow_file.workflow`
- Replacing `application.workflow_filepath` references  to `application.workflow_file.path`

These have been included, along with improved unit testing to catch possible issues in the future.