### PR TITLE
FIX: renamed the deprecated workflow.mco to workflow.mco_model

### DIFF
--- a/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco.py
+++ b/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco.py
@@ -42,7 +42,7 @@ class TestRandomSamplingMCO(unittest.TestCase):
             KPISpecification()
         ]
 
-        self.evaluator.workflow.mco = model
+        self.evaluator.workflow.mco_model = model
         mock_process = mock.Mock()
         mock_process.communicate = mock.Mock(return_value=(b"2", b"1 0"))
         with mock.patch("subprocess.Popen") as mock_popen:
@@ -62,7 +62,7 @@ class TestRandomSamplingMCO(unittest.TestCase):
             KPISpecification()
         ]
 
-        self.evaluator.workflow.mco = model
+        self.evaluator.workflow.mco_model = model
         kpis = [DataValue(value=1), DataValue(value=2)]
         with mock.patch('force_bdss.api.Workflow.execute',
                         return_value=kpis) as mock_exec:

--- a/enthought_example/example_evaluator/tests/test_subprocess_workflow_evaluator.py
+++ b/enthought_example/example_evaluator/tests/test_subprocess_workflow_evaluator.py
@@ -35,7 +35,7 @@ class TestSubprocessWorkflowEvaluator(unittest.TestCase):
 
     def test__subprocess_solve(self):
         factory = mock.Mock(spec=BaseMCOFactory)
-        self.evaluator.workflow.mco = ExampleMCOModel(factory)
+        self.evaluator.workflow.mco_model = ExampleMCOModel(factory)
 
         with mock.patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value = self.mock_process
@@ -49,7 +49,7 @@ class TestSubprocessWorkflowEvaluator(unittest.TestCase):
             raise Exception
 
         factory = mock.Mock(spec=BaseMCOFactory)
-        self.evaluator.workflow.mco = ExampleMCOModel(factory)
+        self.evaluator.workflow.mco_model = ExampleMCOModel(factory)
 
         with mock.patch('enthought_example.example_mco.example_mco'
                         '.SubprocessWorkflowEvaluator._subprocess_evaluate',

--- a/enthought_example/example_evaluator/tests/test_subprocess_workflow_evaluator.py
+++ b/enthought_example/example_evaluator/tests/test_subprocess_workflow_evaluator.py
@@ -6,32 +6,24 @@ from force_bdss.api import BaseMCOFactory, Workflow
 
 from enthought_example.example_mco.example_mco_model import ExampleMCOModel
 from enthought_example.example_mco.example_mco import (
-    SubprocessWorkflowEvaluator
+    SubprocessWorkflowEvaluator,
 )
 
 
 class TestSubprocessWorkflowEvaluator(unittest.TestCase):
-
     def setUp(self):
 
         self.evaluator = SubprocessWorkflowEvaluator(
-            workflow=Workflow(),
-            workflow_filepath="test_probe.json"
+            workflow=Workflow(), workflow_filepath="test_probe.json"
         )
         self.mock_process = mock.Mock()
-        self.mock_process.communicate = mock.Mock(
-            return_value=(b"2", b"1 0")
-        )
+        self.mock_process.communicate = mock.Mock(return_value=(b"2", b"1 0"))
 
     def test___call_subprocess(self):
 
         # Test simple bash command
-        stdout = self.evaluator._call_subprocess(
-            ['uniq'], ['Hello', 'World']
-        )
-        self.assertEqual(
-            'Hello World', stdout.decode("utf-8").strip()
-        )
+        stdout = self.evaluator._call_subprocess(["uniq"], ["Hello", "World"])
+        self.assertEqual("Hello World", stdout.decode("utf-8").strip())
 
     def test__subprocess_solve(self):
         factory = mock.Mock(spec=BaseMCOFactory)
@@ -44,21 +36,23 @@ class TestSubprocessWorkflowEvaluator(unittest.TestCase):
         self.assertEqual(1, len(kpi_results))
 
     def test_solve_error_mco_communicator(self):
-
         def mock_subprocess_evaluate(self, *args):
             raise Exception
 
         factory = mock.Mock(spec=BaseMCOFactory)
         self.evaluator.workflow.mco_model = ExampleMCOModel(factory)
 
-        with mock.patch('enthought_example.example_mco.example_mco'
-                        '.SubprocessWorkflowEvaluator._subprocess_evaluate',
-                        side_effect=mock_subprocess_evaluate):
+        with mock.patch(
+            "enthought_example.example_mco.example_mco"
+            ".SubprocessWorkflowEvaluator._subprocess_evaluate",
+            side_effect=mock_subprocess_evaluate,
+        ):
             with self.assertRaisesRegex(
-                    RuntimeError,
-                    'SubprocessWorkflowEvaluator failed '
-                    'to run. This is likely due to an error in the '
-                    'BaseMCOCommunicator assigned to '
-                    "<class 'force_bdss.mco.base_mco_factory."
-                    "BaseMCOFactory'>."):
+                RuntimeError,
+                "SubprocessWorkflowEvaluator failed "
+                "to run. This is likely due to an error in the "
+                "BaseMCOCommunicator assigned to "
+                "<class 'force_bdss.mco.base_mco_factory."
+                "BaseMCOFactory'>.",
+            ):
                 self.evaluator.evaluate([1.0])

--- a/enthought_example/example_mco/tests/test_example_mco.py
+++ b/enthought_example/example_mco/tests/test_example_mco.py
@@ -2,31 +2,23 @@ from unittest import mock, TestCase
 
 from traits.api import TraitError
 
-from force_bdss.api import (
-    Workflow, KPISpecification, WorkflowEvaluator
-)
+from force_bdss.api import Workflow, KPISpecification, WorkflowEvaluator
 
 from enthought_example.example_mco.parameters import (
     RangedMCOParameter,
-    RangedMCOParameterFactory
+    RangedMCOParameterFactory,
 )
 
-from enthought_example.example_mco.example_mco import (
-    ExampleMCO
-)
-from enthought_example.example_mco.example_mco_factory import (
-    ExampleMCOFactory
-)
+from enthought_example.example_mco.example_mco import ExampleMCO
+from enthought_example.example_mco.example_mco_factory import ExampleMCOFactory
 
 
 class TestExampleMCO(TestCase):
     def setUp(self):
-        self.plugin = {'id': 'pid', 'name': 'Plugin'}
+        self.plugin = {"id": "pid", "name": "Plugin"}
         self.factory = ExampleMCOFactory(self.plugin)
         self.evaluator = WorkflowEvaluator(
-            workflow=Workflow(),
-            workflow_filepath="whatever"
-
+            workflow=Workflow(), workflow_filepath="whatever"
         )
 
     def test_initialization(self):
@@ -41,11 +33,10 @@ class TestExampleMCO(TestCase):
                 mock.Mock(spec=RangedMCOParameterFactory),
                 lower_bound=1,
                 upper_bound=3,
-                initial_value=2)
+                initial_value=2,
+            )
         ]
-        model.kpis = [
-            KPISpecification()
-        ]
+        model.kpis = [KPISpecification()]
 
         self.evaluator.workflow.mco_model = model
         mock_process = mock.Mock()
@@ -78,8 +69,9 @@ class TestExampleMCO(TestCase):
         # test whether argument order matters on object creation
         model_data = {"initial_value": 2, "upper_bound": 3, "lower_bound": 1}
         model.parameters = [
-            RangedMCOParameter(mock.Mock(spec=RangedMCOParameterFactory),
-                               **model_data)
+            RangedMCOParameter(
+                mock.Mock(spec=RangedMCOParameterFactory), **model_data
+            )
         ]
 
         mock_process = mock.Mock()

--- a/enthought_example/example_mco/tests/test_example_mco.py
+++ b/enthought_example/example_mco/tests/test_example_mco.py
@@ -47,7 +47,7 @@ class TestExampleMCO(TestCase):
             KPISpecification()
         ]
 
-        self.evaluator.workflow.mco = model
+        self.evaluator.workflow.mco_model = model
         mock_process = mock.Mock()
         mock_process.communicate = mock.Mock(return_value=(b"1 2 3", b""))
         with mock.patch("subprocess.Popen") as mock_popen:

--- a/enthought_example/tests/example_workflows/empty_workflow.json
+++ b/enthought_example/tests/example_workflows/empty_workflow.json
@@ -1,7 +1,7 @@
 {
     "version": "1",
     "workflow": {
-        "mco": null,
+        "mco_model": null,
         "execution_layers": [],
         "notification_listeners": []
     }


### PR DESCRIPTION
This PR fixes the reference to `Workflow.mco` which was changed in [#257](https://github.com/force-h2020/force-bdss/pull/257).