### PR TITLE
TST: Remove deprecated references to Workflow.mco attribute

### DIFF
--- a/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco.py
+++ b/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco.py
@@ -42,7 +42,7 @@ class TestRandomSamplingMCO(unittest.TestCase):
             KPISpecification()
         ]
 
-        self.evaluator.workflow.mco = model
+        self.evaluator.workflow.mco_model = model
         mock_process = mock.Mock()
         mock_process.communicate = mock.Mock(return_value=(b"2", b"1 0"))
         with mock.patch("subprocess.Popen") as mock_popen:
@@ -62,7 +62,7 @@ class TestRandomSamplingMCO(unittest.TestCase):
             KPISpecification()
         ]
 
-        self.evaluator.workflow.mco = model
+        self.evaluator.workflow.mco_model = model
         kpis = [DataValue(value=1), DataValue(value=2)]
         with mock.patch('force_bdss.api.Workflow.execute',
                         return_value=kpis) as mock_exec:

--- a/enthought_example/example_contributed_ui/example_contributed_ui.py
+++ b/enthought_example/example_contributed_ui/example_contributed_ui.py
@@ -27,9 +27,12 @@ class ExampleContributedUI(ContributedUI):
     @on_trait_change('lower,upper,power')
     def workflow_data_update(self):
         wf_data = {
-            "mco": self._mco_data(),
-            "execution_layers": self._execution_layer_data(),
-            "notification_listeners":  self._notification_listener_data()
+            "version": "1",
+            "workflow": {
+                "mco_model": self._mco_data(),
+                "execution_layers": self._execution_layer_data(),
+                "notification_listeners":  self._notification_listener_data()
+            }
         }
         self.workflow_data = wf_data
         return wf_data

--- a/enthought_example/example_evaluator/tests/test_subprocess_workflow_evaluator.py
+++ b/enthought_example/example_evaluator/tests/test_subprocess_workflow_evaluator.py
@@ -35,7 +35,7 @@ class TestSubprocessWorkflowEvaluator(unittest.TestCase):
 
     def test__subprocess_solve(self):
         factory = mock.Mock(spec=BaseMCOFactory)
-        self.evaluator.workflow.mco = ExampleMCOModel(factory)
+        self.evaluator.workflow.mco_model = ExampleMCOModel(factory)
 
         with mock.patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value = self.mock_process
@@ -49,7 +49,7 @@ class TestSubprocessWorkflowEvaluator(unittest.TestCase):
             raise Exception
 
         factory = mock.Mock(spec=BaseMCOFactory)
-        self.evaluator.workflow.mco = ExampleMCOModel(factory)
+        self.evaluator.workflow.mco_model = ExampleMCOModel(factory)
 
         with mock.patch('enthought_example.example_mco.example_mco'
                         '.SubprocessWorkflowEvaluator._subprocess_evaluate',

--- a/enthought_example/example_mco/tests/test_example_mco.py
+++ b/enthought_example/example_mco/tests/test_example_mco.py
@@ -47,7 +47,7 @@ class TestExampleMCO(TestCase):
             KPISpecification()
         ]
 
-        self.evaluator.workflow.mco = model
+        self.evaluator.workflow.mco_model = model
         mock_process = mock.Mock()
         mock_process.communicate = mock.Mock(return_value=(b"1 2 3", b""))
         with mock.patch("subprocess.Popen") as mock_popen:

--- a/enthought_example/tests/example_workflows/empty_workflow.json
+++ b/enthought_example/tests/example_workflows/empty_workflow.json
@@ -1,7 +1,7 @@
 {
     "version": "1",
     "workflow": {
-        "mco": null,
+        "mco_model": null,
         "execution_layers": [],
         "notification_listeners": []
     }


### PR DESCRIPTION
Since https://github.com/force-h2020/force-bdss/pull/257, the `Workflow.mco` attribute has been renamed to `Workflow.mco_model`.

This only has impact on the test suite, where `mco` is directly referenced