### PR TITLE
DEP: Replacing deprecated BaseMCO.notify_new_event method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ before_install:
     - edm install -y --version 3.6 click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss
-    - git checkout dev/workflow-event
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - git clone git://github.com/force-h2020/force-wfmanager.git
     - pushd force-wfmanager && edm run -- python -m ci install && popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
     - edm install -y --version 3.6 click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss
+    - git checkout dev/workflow-event
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - git clone git://github.com/force-h2020/force-wfmanager.git
     - pushd force-wfmanager && edm run -- python -m ci install && popd

--- a/eggbox_potential_sampler/random_sampling_mco/mco.py
+++ b/eggbox_potential_sampler/random_sampling_mco/mco.py
@@ -50,8 +50,8 @@ class RandomSamplingMCO(BaseMCO):
 
             kpis = single_point_evaluator.evaluate(trial_position)
 
-            single_point_evaluator.mco_model.notify_new_point(
+            single_point_evaluator.mco_model.notify_progress_event(
                 [DataValue(value=v) for v in trial_position],
                 [DataValue(value=v) for v in kpis],
-                [1 / len(kpis)] * len(kpis)
+                weights=[1 / len(kpis)] * len(kpis)
             )

--- a/eggbox_potential_sampler/random_sampling_mco/mco.py
+++ b/eggbox_potential_sampler/random_sampling_mco/mco.py
@@ -50,7 +50,7 @@ class RandomSamplingMCO(BaseMCO):
 
             kpis = single_point_evaluator.evaluate(trial_position)
 
-            self.notify_new_point(
+            single_point_evaluator.mco_model.notify_new_point(
                 [DataValue(value=v) for v in trial_position],
                 [DataValue(value=v) for v in kpis],
                 [1 / len(kpis)] * len(kpis)

--- a/enthought_example/example_evaluator/subprocess_workflow.py
+++ b/enthought_example/example_evaluator/subprocess_workflow.py
@@ -109,7 +109,7 @@ class SubprocessWorkflow(Workflow):
                     writer = WorkflowWriter()
                     writer.write(self, tmp_file.name)
                     return self._subprocess_evaluate(
-                        parameter_values, tmp_file)
+                        parameter_values, tmp_file.name)
 
         except Exception:
             message = (

--- a/enthought_example/example_mco/example_mco.py
+++ b/enthought_example/example_mco/example_mco.py
@@ -38,7 +38,7 @@ class ExampleMCO(BaseMCO):
     - report new events as they happen, specifically, when the MCO has
       computed a new result, it can be broadcast with the notify_new_point::
 
-            self.notify_new_point(
+            evaluator.mco_model.notify_new_point(
                 optimal_point=[
                     DataValue(value=parameter_1),
                     DataValue(value=parameter_2),
@@ -104,6 +104,7 @@ class ExampleMCO(BaseMCO):
 
             # When there is new data, this operation informs the system that
             # new data has been received. It must be a dictionary as given.
-            self.notify_new_point([DataValue(value=v) for v in value],
-                                  [DataValue(value=v) for v in kpis],
-                                  [1 / len(kpis)] * len(kpis))
+            single_point_evaluator.mco_model.notify_new_point(
+                [DataValue(value=v) for v in value],
+                [DataValue(value=v) for v in kpis],
+                [1 / len(kpis)] * len(kpis))

--- a/enthought_example/example_mco/example_mco.py
+++ b/enthought_example/example_mco/example_mco.py
@@ -104,7 +104,8 @@ class ExampleMCO(BaseMCO):
 
             # When there is new data, this operation informs the system that
             # new data has been received. It must be a dictionary as given.
-            single_point_evaluator.mco_model.notify_new_point(
+            single_point_evaluator.mco_model.notify_progress_event(
                 [DataValue(value=v) for v in value],
                 [DataValue(value=v) for v in kpis],
-                [1 / len(kpis)] * len(kpis))
+                weights=[1 / len(kpis)] * len(kpis)
+            )


### PR DESCRIPTION
The PR implements minor updates to account for changes introduced in https://github.com/force-h2020/force-bdss/pull/269