### PR TITLE
DEV: Release of Force Enthought Example 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git -b dev/version-0.4.0
     - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
-    - git clone git://github.com/force-h2020/force-wfmanager.git
+    - git clone git://github.com/force-h2020/force-wfmanager.git -b dev/version-0.4.0
     - pushd force-wfmanager && edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git -b dev/version-0.4.0
+    - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
-    - git clone git://github.com/force-h2020/force-wfmanager.git -b dev/version-0.4.0
+    - git clone git://github.com/force-h2020/force-wfmanager.git
     - pushd force-wfmanager
     - edm run -- python -m ci install && popd
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,48 @@ Changelog
 Version 0.3.0
 -------------
 
-- Moved to pure python 3 build (#13)
+Released:
+
+Release notes
+~~~~~~~~~~~~~
+
+Version 0.3.0 is a major update to the Force Enthought Example plugin,
+and includes a number of backward incompatible changes, including:
+
+* Strong dependency on ``force_bdss`` package version 0.4.0
+* Weak dependency on ``force_wfmanager`` package version 0.4.0
+* Inclusion of custom UI features that can be contributed by the ``ServiceOfferExtensionPlugin``
+  class
+
+The following people contributed
+code changes for this release:
+
+* Stefano Borini
+* Matthew Evans
+* James Johnson
+* Nicola De Mitri
+* Frank Longford
+* Petr Kungurtsev
+
+Features
+~~~~~~~~
+
+
+Changes
+~~~~~~~
+
+
+Removals
+~~~~~~~~
+
+Documentation
+~~~~~~~~~~~~~
+
+Maintenance and code organization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Moved to pure python 3 build (#13)
+
 
 Version 0.2.0
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,21 +30,36 @@ code changes for this release:
 Features
 ~~~~~~~~
 
+* New Potential Energy Surface Sampler included in ``EggboxPlugin`` (#21)
+* New custom UI features contributed to WfManager (#26, #28, #29, #40), both ``ContributedUI``
+  and ``BaseDataView`` subclasses
 
 Changes
 ~~~~~~~
 
+* Now only supporting unicode compatible strings (#14)
+* References to ``Workflow.mco`` attribute updated to ``Workflow.mco_model`` (#35, #36)
 
 Removals
 ~~~~~~~~
 
+* Removed references to ``BaseFactory.plugin`` attribute (#33)
+* Removal of deprecated ``BaseMCO.notify_driver_event`` method (#38)
+* Removal of need for arbitrary weights to be reported for each KPI in the MCO (#39)
+
 Documentation
 ~~~~~~~~~~~~~
+
+* New auto-generated Sphinx documentation (#22, #31)
 
 Maintenance and code organization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Moved to pure python 3 build (#13)
+* EDM version updated to 2.1.0 in Travis CI (#27, #42) using python 3.6 bootstrap environment (#20)
+* Travis CI now runs 2 jobs: Linux Ubuntu Bionic (#27) and MacOS (#27)
+* Better handling of ClickExceptions in CI (#27)
+
 
 
 Version 0.2.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "0.3.0.dev0"
+VERSION = "0.3.0"
 
 
 # Read description
@@ -42,6 +42,6 @@ setup(
     },
     packages=find_packages(),
     install_requires=[
-        "force_bdss >= 0.2.0",
+        "force_bdss >= 0.4.0",
     ]
 )


### PR DESCRIPTION
This PR announces the release of version 0.3.0 of the Force Enthought Example plugin

Full change log can be found in `CHANGES.rst`