### PR TITLE
DEV: Updating to version to 0.3.1.dev0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,21 @@
 Changelog 
 ---------
 
-Version 0.3.0
+Version 0.3.1
 -------------
 
 Released:
+
+Release notes
+~~~~~~~~~~~~~
+
+Bug fixes for version 0.3.0
+
+
+Version 0.3.0
+-------------
+
+Released: 24 Feb 2020
 
 Release notes
 ~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "0.3.0"
+VERSION = "0.3.1.dev0"
 
 
 # Read description


### PR DESCRIPTION
This PR updates the current version to `0.3.1.dev0`, in expectation of a minor release `0.3.1` containing bug fixes to 0.3.0 (#44)