### PR TITLE
FIX: ExampleContributedUI workflow template

### DIFF
--- a/enthought_example/example_contributed_ui/example_contributed_ui.py
+++ b/enthought_example/example_contributed_ui/example_contributed_ui.py
@@ -27,7 +27,7 @@ class ExampleContributedUI(ContributedUI):
     @on_trait_change('lower,upper,power')
     def workflow_data_update(self):
         wf_data = {
-            "version": "1",
+            "version": "1.1",
             "workflow": {
                 "mco_model": self._mco_data(),
                 "execution_layers": self._execution_layer_data(),
@@ -77,52 +77,58 @@ class ExampleContributedUI(ContributedUI):
 
     def _execution_layer_data(self):
         return [
-            [
-                {
-                    "id": ".".join([
-                        _ENTHOUGHT_PLUGIN_ID, "example_data_source"
-                    ]),
-                    "model_data": {
-                        "power": self.power,
-                        "cuba_type_in": "number",
-                        "cuba_type_out": "number_sq",
-                        "input_slot_info": [
-                            {
-                                "source": "Environment",
-                                "name": "input_number"
+            {
+                'data_sources':
+                    [
+                        {
+                            "id": ".".join([
+                                _ENTHOUGHT_PLUGIN_ID, "example_data_source"
+                            ]),
+                            "model_data": {
+                                "power": self.power,
+                                "cuba_type_in": "number",
+                                "cuba_type_out": "number_sq",
+                                "input_slot_info": [
+                                    {
+                                        "source": "Environment",
+                                        "name": "input_number"
+                                    }
+                                ],
+                                "output_slot_info": [
+                                    {
+                                        "name": "input_number_sq"
+                                    }
+                                ]
                             }
-                        ],
-                        "output_slot_info": [
-                            {
-                                "name": "input_number_sq"
+                        }
+                    ],
+            },
+            {
+                'data_sources':
+                    [
+                        {
+                            "id": ".".join([
+                                _ENTHOUGHT_PLUGIN_ID, "example_data_source"
+                            ]),
+                            "model_data": {
+                                "power": 4.0,
+                                "cuba_type_in": "number_sq",
+                                "cuba_type_out": "number_8",
+                                "input_slot_info": [
+                                    {
+                                        "source": "Environment",
+                                        "name": "input_number_sq"
+                                    }
+                                ],
+                                "output_slot_info": [
+                                    {
+                                        "name": "input_number_8"
+                                    }
+                                ]
                             }
-                        ]
-                    }
-                }
-            ],
-            [
-                {
-                    "id": ".".join([
-                        _ENTHOUGHT_PLUGIN_ID, "example_data_source"
-                    ]),
-                    "model_data": {
-                        "power": 4.0,
-                        "cuba_type_in": "number_sq",
-                        "cuba_type_out": "number_8",
-                        "input_slot_info": [
-                            {
-                                "source": "Environment",
-                                "name": "input_number_sq"
-                            }
-                        ],
-                        "output_slot_info": [
-                            {
-                                "name": "input_number_8"
-                            }
-                        ]
-                    }
-                }
-            ]
+                        }
+                    ]
+            }
         ]
 
     def _notification_listener_data(self):

--- a/enthought_example/example_contributed_ui/tests/test_example_contributed_ui.py
+++ b/enthought_example/example_contributed_ui/tests/test_example_contributed_ui.py
@@ -47,7 +47,7 @@ class TestExampleContributedUI(unittest.TestCase):
         self.assertEqual(2, len(execution_layer_data))
 
         for execution_layer in execution_layer_data:
-            for data_source in execution_layer:
+            for data_source in execution_layer['data_sources']:
                 keys = list(data_source.keys())
                 self.assertListEqual(['id', 'model_data'], keys)
 


### PR DESCRIPTION
The PR closes #44 

It updates the workflow template generated by the `ExampleContributedUI` class to version 1.1 formatting. Without this fix, the MCO will not load properly