### PR TITLE
FIX: Updates to ConvergencePlot for new API

### DIFF
--- a/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
+++ b/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
@@ -72,7 +72,7 @@ class ConvergencePlot(BasePlot):
         the callback update.
         This method is called when the `y` axis is changed.
         """
-        if self.y == "" or len(self.data_arrays) == 0:
+        if self.y == "" or len(self.analysis_model.evaluation_steps) == 0:
             self._plot_data.set_data("y", [])
         else:
             self._plot.y_axis.title = self.y
@@ -99,12 +99,10 @@ class ConvergencePlot(BasePlot):
         """Calculates convergence data to display in the y axis"""
         new_data_array = []
 
-        y_index = self.displayable_value_names.index(self.y)
+        column = self.analysis_model.column(self.y)
 
-        for ind, _ in enumerate(self.data_arrays[y_index], start=1):
-            new_data_array.append(
-                min(self.data_arrays[y_index][:ind])
-            )
+        for ind, _ in enumerate(column, start=1):
+            new_data_array.append(min(column[:ind]))
 
         return new_data_array
 

--- a/eggbox_potential_sampler/sampling_data_view/tests/test_sampling_data_view.py
+++ b/eggbox_potential_sampler/sampling_data_view/tests/test_sampling_data_view.py
@@ -48,7 +48,7 @@ class TestConvergencePlot(unittest.TestCase):
         self.analysis_model = AnalysisModel()
         self.data_view = SamplingDataView(analysis_model=self.analysis_model)
         self.plot = self.data_view.sampling_plot
-        self.analysis_model.header = ("x", "y", "E")
+        self.analysis_model.notify(("x", "y", "E"))
 
     def check_update_is_requested_and_apply(self):
         # check
@@ -64,11 +64,11 @@ class TestConvergencePlot(unittest.TestCase):
         for datum in [
                 (1, 3, 8), (2, 5, 7.7), (3, 2.6, 7.6), (4, 2.5, 7.62),
                 (5, 2.47, 7.543), (6, 2.465, 7.54)]:
-            self.analysis_model._add_evaluation_step(datum)
+            self.analysis_model.notify(datum)
         self.check_update_is_requested_and_apply()
 
     def test_init(self):
-        self.analysis_model._add_evaluation_step((1.0, 1.0, 1.0))
+        self.analysis_model.notify((1.0, 1.0, 1.0))
         self.plot._update_displayable_value_names()
         self.assertIsInstance(self.plot._axis, LinePlot)
         self.assertEqual('iteration', self.plot._plot.x_axis.title)

--- a/eggbox_potential_sampler/sampling_data_view/tests/test_sampling_data_view.py
+++ b/eggbox_potential_sampler/sampling_data_view/tests/test_sampling_data_view.py
@@ -48,14 +48,13 @@ class TestConvergencePlot(unittest.TestCase):
         self.analysis_model = AnalysisModel()
         self.data_view = SamplingDataView(analysis_model=self.analysis_model)
         self.plot = self.data_view.sampling_plot
-        self.analysis_model.value_names = ("x", "y", "E")
+        self.analysis_model.header = ("x", "y", "E")
 
     def check_update_is_requested_and_apply(self):
         # check
         self.assertTrue(self.plot.update_required)
         self.assertTrue(self.plot.plot_updater.active)
         # update
-        self.plot._update_data_arrays()
         self.plot._update_displayable_value_names()
         self.plot._update_plot()
         self.plot.update_required = False
@@ -65,11 +64,11 @@ class TestConvergencePlot(unittest.TestCase):
         for datum in [
                 (1, 3, 8), (2, 5, 7.7), (3, 2.6, 7.6), (4, 2.5, 7.62),
                 (5, 2.47, 7.543), (6, 2.465, 7.54)]:
-            self.analysis_model.add_evaluation_step(datum)
+            self.analysis_model._add_evaluation_step(datum)
         self.check_update_is_requested_and_apply()
 
     def test_init(self):
-        self.analysis_model.add_evaluation_step((1.0, 1.0, 1.0))
+        self.analysis_model._add_evaluation_step((1.0, 1.0, 1.0))
         self.plot._update_displayable_value_names()
         self.assertIsInstance(self.plot._axis, LinePlot)
         self.assertEqual('iteration', self.plot._plot.x_axis.title)


### PR DESCRIPTION
Since https://github.com/force-h2020/force-wfmanager/pull/365, there have been some key updates to the API of `AnalysisModel` and `BasePlot` subclasses. This PR updates the `ConvergencePlot` class to account for these changes.