### PR TITLE
FIX: SubprocessWorkflow error running from WfManager

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,7 +36,7 @@ def mock_modules():
             return Mock()
 
     sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
-    print 'mocking {}'.format(MOCK_MODULES)
+    print('mocking {}'.format(MOCK_MODULES))
 
 mock_modules()
 

--- a/enthought_example/example_evaluator/subprocess_workflow.py
+++ b/enthought_example/example_evaluator/subprocess_workflow.py
@@ -22,15 +22,12 @@ class SubprocessWorkflow(Workflow):
 
     def __getstate__(self):
         """Overloads the Workflow.__getstate__ method to ensure
-        that no UINotificationListeners instances are serialised.
+        that no BaseNotificationListeners instances are serialised.
         Allowing so would cause duplicate messages to be sent to
         the UI from a single socket when the force_bdss is run
         on a new process."""
         data = super(SubprocessWorkflow, self).__getstate__()
-        notification_listeners = data['notification_listeners']
-        for listener_data in notification_listeners:
-            if 'ui_notification' in listener_data['id']:
-                notification_listeners.remove(listener_data)
+        data['notification_listeners'] = []
         return data
 
     def _call_subprocess(self, command, user_input):

--- a/enthought_example/example_evaluator/subprocess_workflow.py
+++ b/enthought_example/example_evaluator/subprocess_workflow.py
@@ -20,6 +20,19 @@ class SubprocessWorkflow(Workflow):
     #: The path to the force_bdss executable
     executable_path = Unicode(transient=True)
 
+    def __getstate__(self):
+        """Overloads the Workflow.__getstate__ method to ensure
+        that no UINotificationListeners instances are serialised.
+        Allowing so would cause duplicate messages to be sent to
+        the UI from a single socket when the force_bdss is run
+        on a new process."""
+        data = super(SubprocessWorkflow, self).__getstate__()
+        notification_listeners = data['notification_listeners']
+        for listener_data in notification_listeners:
+            if 'ui_notification' in listener_data['id']:
+                notification_listeners.remove(listener_data)
+        return data
+
     def _call_subprocess(self, command, user_input):
         """Calls a subprocess to perform a command with parsed
         user_input"""

--- a/enthought_example/example_evaluator/tests/test_subprocess_workflow.py
+++ b/enthought_example/example_evaluator/tests/test_subprocess_workflow.py
@@ -1,6 +1,5 @@
-import unittest
-
-from unittest import mock
+import testfixtures
+from unittest import mock, TestCase
 
 from force_bdss.api import BaseMCOFactory
 
@@ -9,14 +8,47 @@ from enthought_example.example_mco.example_mco import (
     SubprocessWorkflow
 )
 
+WORKFLOW_GETSTATE_PATH = 'force_bdss.core.workflow.Workflow.__getstate__'
 
-class TestSubprocessWorkflow(unittest.TestCase):
+
+def mock_workflow_getstate():
+    """Mocks the Workflow.__getstate__ method to include a
+     UINotificationListener instance"""
+    return {
+        "mco_model": None,
+        "execution_layers": [],
+        "notification_listeners": [
+            {"id": "force.bdss.enthought.plugin.some_listener.v0"
+                   ".factory.some_listener",
+             "model_data": {}},
+            {"id":  "force.bdss.enthought.plugin.ui_notification.v0"
+                    ".factory.ui_notification",
+             "model_data":  {}}
+        ]
+    }
+
+
+class TestSubprocessWorkflow(TestCase):
 
     def setUp(self):
         self.evaluator = SubprocessWorkflow(
             workflow_filepath="test_probe.json")
         self.mock_process = mock.Mock()
-        self.mock_process.communicate = mock.Mock(return_value=(b"2", b"1 0"))
+        self.mock_process.communicate = mock.Mock(
+            return_value=(b"2", b"1 0"))
+
+    def test_getstate(self):
+        with mock.patch(WORKFLOW_GETSTATE_PATH) as mock_getstate:
+            mock_getstate.side_effect = mock_workflow_getstate
+            self.assertDictEqual(
+                {"mco_model": None,
+                 "execution_layers": [],
+                 "notification_listeners": [
+                     {"id": "force.bdss.enthought.plugin.some_listener.v0"
+                            ".factory.some_listener",
+                      "model_data": {}},
+                 ]},
+                self.evaluator.__getstate__())
 
     def test___call_subprocess(self):
 
@@ -45,11 +77,12 @@ class TestSubprocessWorkflow(unittest.TestCase):
         with mock.patch('enthought_example.example_mco.example_mco'
                         '.SubprocessWorkflow._subprocess_evaluate',
                         side_effect=mock_subprocess_evaluate):
-            with self.assertRaisesRegex(
-                    RuntimeError,
-                    'SubprocessWorkflow failed '
-                    'to run. This is likely due to an error in the '
-                    'BaseMCOCommunicator assigned to '
-                    "<class 'force_bdss.mco.base_mco_factory."
-                    "BaseMCOFactory'>."):
-                self.evaluator.evaluate([1.0])
+            with testfixtures.LogCapture():
+                with self.assertRaisesRegex(
+                        RuntimeError,
+                        'SubprocessWorkflow failed '
+                        'to run. This is likely due to an error in the '
+                        'BaseMCOCommunicator assigned to '
+                        "<class 'force_bdss.mco.base_mco_factory."
+                        "BaseMCOFactory'>."):
+                    self.evaluator.evaluate([1.0])

--- a/enthought_example/example_evaluator/tests/test_subprocess_workflow.py
+++ b/enthought_example/example_evaluator/tests/test_subprocess_workflow.py
@@ -12,8 +12,8 @@ WORKFLOW_GETSTATE_PATH = 'force_bdss.core.workflow.Workflow.__getstate__'
 
 
 def mock_workflow_getstate():
-    """Mocks the Workflow.__getstate__ method to include a
-     UINotificationListener instance"""
+    """Mocks the Workflow.__getstate__ method to include
+     BaseNotificationListener instances"""
     return {
         "mco_model": None,
         "execution_layers": [],
@@ -43,11 +43,7 @@ class TestSubprocessWorkflow(TestCase):
             self.assertDictEqual(
                 {"mco_model": None,
                  "execution_layers": [],
-                 "notification_listeners": [
-                     {"id": "force.bdss.enthought.plugin.some_listener.v0"
-                            ".factory.some_listener",
-                      "model_data": {}},
-                 ]},
+                 "notification_listeners": []},
                 self.evaluator.__getstate__())
 
     def test___call_subprocess(self):

--- a/enthought_example/tests/fixtures/powers_example.json
+++ b/enthought_example/tests/fixtures/powers_example.json
@@ -77,6 +77,10 @@
             }
         ],
         "notification_listeners": [
+            {
+                "id": "force.bdss.enthought.plugin.example.v0.factory.example_notification_listener",
+                "model_data": {}
+            }
         ]
     }
 }

--- a/enthought_example/tests/fixtures/powers_example.json
+++ b/enthought_example/tests/fixtures/powers_example.json
@@ -1,0 +1,82 @@
+{
+    "version": "1.1",
+    "workflow": {
+        "mco_model": {
+            "id": "force.bdss.enthought.plugin.example.v0.factory.example_mco",
+            "model_data": {
+                "parameters": [
+                    {
+                        "id": "force.bdss.enthought.plugin.example.v0.factory.example_mco.parameter.ranged",
+                        "model_data": {
+                            "lower_bound": 0.0,
+                            "upper_bound": 10.0,
+                            "initial_value": 2.0,
+                            "name": "input_number",
+                            "type": "number"
+                        }
+                    }
+                ],
+                "kpis": [
+                    {
+                        "name": "input_number_sq",
+                        "objective": "MINIMISE"
+                    },
+                    {
+                        "name": "input_number_8",
+                        "objective": "MAXIMISE"
+                    }
+                ]
+            }
+        },
+        "execution_layers": [
+            {"data_sources":
+                [
+                    {
+                        "id": "force.bdss.enthought.plugin.example.v0.factory.example_data_source",
+                        "model_data": {
+                            "power": 2.0,
+                            "cuba_type_in": "number",
+                            "cuba_type_out": "number_sq",
+                            "input_slot_info": [
+                                {
+                                    "source": "Environment",
+                                    "name": "input_number"
+                                }
+                            ],
+                            "output_slot_info": [
+                                {
+                                    "name": "input_number_sq"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {"data_sources":
+                [
+                    {
+                        "id": "force.bdss.enthought.plugin.example.v0.factory.example_data_source",
+                        "model_data": {
+                            "power": 4.0,
+                            "cuba_type_in": "number_sq",
+                            "cuba_type_out": "number_8",
+                            "input_slot_info": [
+                                {
+                                    "source": "Environment",
+                                    "name": "input_number_sq"
+                                }
+                            ],
+                            "output_slot_info": [
+                                {
+                                    "name": "input_number_8"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ],
+        "notification_listeners": [
+        ]
+    }
+}


### PR DESCRIPTION
This PR approaches #51 and closes #50 

## Background
The `SubprocessWorkflow` spawns a new subprocess running the `force_bdss` in `evaluate` mode in order to generate KPI values, whilst passing in a copy of itself as a JSON file. It is used in `ExampleMCO.run` as a way to remotely execute the (possibly heavy) `Workflow.evaluate` method. 

Since https://github.com/force-h2020/force-bdss/pull/320, the `EvaluateOperation` now initialises notification listeners, and so duplicate messages were being sent to the `WfManager` when using the `ExampleMCO`:

#### Steps to run any `BaseMCO` from `force_wfmanager`
1. add `UINotificationListenerModels` to `Workflow`
2. serialize `Workflow` to `temporary_file_1`
3. spawn new subprocess running `force_bdss` in `optimize` mode using `temporary_file_1`
4. create new `Workflow` instance from `temporary_file_1`
5. **_create `BaseNotificationListener ` instances to communicate with `force_wfmanager`_**

#### Extra steps for `ExampleMCO`
6. create `SubprocessWorkflow` instance from `Workflow`
7. serialize `SubprocessWorkflow` to `temporary_file_2`
8. spawn new subprocess running `force_bdss` in `evaluate` mode using `temporary_file_2`
9. create new `Workflow` instance from `temporary_file_2`
10. **_create `BaseNotificationListener` instances to communicate with `force_wfmanager`_**

This new behaviour also leads to #51, since duplicate `stdout` messages were broadcast from `ExampleNotificationListener`.

## Solution
A short term solution is to remove any serialised `BaseNotificationListenerModel` instances from `temporary_file_2`. Unfortunately, that also removes any control that we have to stop or pausing the `EvaluateOperation` from the UI. It also prevents any `BaseDriverEvents` created during a `Workflow.evaluate` call from being transmitted. 

Ultimately, we should redesign the BDSS to be able to act as its own ZMQ server: relaying messages to and from the WfManager as well as any remote executions of the `EvaluateOperation`.

## Change log:
- `SubprocessWorkflow.__getstate__` method now removes any notification listener objects with a `ui_notification` reference
- New example workflow file: `enthought_example/tests/fixtures/powers_example.json` included that runs an `ExampleMCO`