### PR TITLE
MAINT: Get Codecov reporting again

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -1,5 +1,5 @@
 import click
-from subprocess import check_call
+import subprocess
 
 DEFAULT_PYTHON_VERSION = "3.6"
 PYTHON_VERSIONS = ["3.6"]
@@ -27,24 +27,36 @@ python_version_option = click.option(
 @python_version_option
 def install(python_version):
     env_name = get_env_name(python_version)
-    check_call([
+    returncode = subprocess.call([
         "edm", "install", "-e", env_name,
         "--yes"] + ADDITIONAL_CORE_DEPS)
 
-    check_call([
-        "edm", "run", "-e", env_name, "--",
-        "pip", "install", "-e", "."])
+    if returncode:
+        raise click.ClickException("Error while installing EDM dependencies.")
+
+    returncode = edm_run(env_name, ["pip", "install", "-e", "."])
+    if returncode:
+        raise click.ClickException("Error while installing the local package.")
 
 
 @cli.command(help="Run the tests")
 @python_version_option
-def test(python_version):
+@click.option(
+    "--verbose/--quiet",
+    default=True,
+    help="Run tests in verbose mode? [default: --verbose]",
+)
+def test(python_version, verbose):
     env_name = get_env_name(python_version)
 
-    check_call([
-        "edm", "run", "-e", env_name, "--", "python", "-m", "unittest",
-        "discover", "-v"
-    ])
+    verbosity_args = ["--verbose"] if verbose else []
+
+    returncode = edm_run(
+        env_name, ["python", "-m", "unittest", "discover"] + verbosity_args
+    )
+
+    if returncode:
+        raise click.ClickException("There were test failures.")
 
 
 @cli.command(help="Run flake")
@@ -52,7 +64,11 @@ def test(python_version):
 def flake8(python_version):
     env_name = get_env_name(python_version)
 
-    check_call(["edm", "run", "-e", env_name, "--", "flake8", "."])
+    returncode = edm_run(env_name, ["flake8", "."])
+    if returncode:
+        raise click.ClickException(
+            "Flake8 exited with exit status {}".format(returncode)
+        )
 
 
 @cli.command(help="Runs the coverage")
@@ -60,8 +76,20 @@ def flake8(python_version):
 def coverage(python_version):
     env_name = get_env_name(python_version)
 
-    check_call(["edm", "run", "-e", env_name, "--",
-                "coverage", "run", "-m", "unittest", "discover"])
+    returncode = edm_run(
+        env_name, ["coverage", "run", "-m", "unittest", "discover"]
+    )
+    if returncode:
+        raise click.ClickException("There were test failures.")
+
+    returncode = edm_run(env_name, ["pip", "install", "codecov"])
+    if not returncode:
+        returncode = edm_run(env_name, ["codecov"])
+
+    if returncode:
+        raise click.ClickException(
+            "There were errors while installing and running codecov."
+        )
 
 
 @cli.command(help="Builds the documentation")
@@ -69,7 +97,11 @@ def coverage(python_version):
 def docs(python_version):
     env_name = get_env_name(python_version)
 
-    check_call(["edm", "run", "-e", env_name, "--", "make", "html"], cwd="doc")
+    returncode = edm_run(env_name, ["make", "html"], cwd="doc")
+    if returncode:
+        raise click.ClickException(
+            "There were errors while building the documentation."
+        )
 
 
 def get_env_name(python_version):
@@ -78,6 +110,10 @@ def get_env_name(python_version):
 
 def remove_dot(python_version):
     return "".join(python_version.split('.'))
+
+
+def edm_run(env_name, cmd, cwd=None):
+    return subprocess.call(["edm", "run", "-e", env_name, "--"] + cmd, cwd=cwd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Codecov has not been posting a report to PRs for this repository since #34. 

It looks like for some reason the `.coverage` file was not being generated by `python -m ci coverage` and therefore not uploaded to Codecov by TravisCI.

This PR attempts to get it working again. By doing so we also update some of the other `click` functions in `ci/__main__.py` to the same state as the rest of our FORCE repos.