### PR TITLE
enthought copyright header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ cache:
       - "$HOME/.ccache"
 
 before_install:
+    - cd ${HOME}
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then ccache -s ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=/usr/lib/ccache:${PATH} ; fi
     - export EDM_INSTALLER=${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX}
     - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/${EDM_INSTALLER}
@@ -37,13 +39,14 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools
+    - cd ${HOME}/build/force-h2020/
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - git clone git://github.com/force-h2020/force-wfmanager.git
     - pushd force-wfmanager
     - edm run -- python -m ci install && popd
-    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
+    - cd force-bdss-plugin-enthought-example
 script:
     - edm run -- python -m ci install
     - edm run -- python -m ci flake8

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 FORCE - EU Horizon2020
+Copyright (c) 2017, Enthought Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import click
 import subprocess
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import sphinx.environment
 from docutils.utils import get_source_line
 import sys

--- a/eggbox_potential_sampler/__init__.py
+++ b/eggbox_potential_sampler/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/eggbox_potential_sampler/eggbox_pes_data_source/__init__.py
+++ b/eggbox_potential_sampler/eggbox_pes_data_source/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/eggbox_potential_sampler/eggbox_pes_data_source/data_source.py
+++ b/eggbox_potential_sampler/eggbox_pes_data_source/data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import itertools
 
 import numpy as np

--- a/eggbox_potential_sampler/eggbox_pes_data_source/factory.py
+++ b/eggbox_potential_sampler/eggbox_pes_data_source/factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSourceFactory
 
 from .model import EggboxPESDataSourceModel

--- a/eggbox_potential_sampler/eggbox_pes_data_source/model.py
+++ b/eggbox_potential_sampler/eggbox_pes_data_source/model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import numpy as np
 
 from traits.api import Bool, Float, List, on_trait_change, Unicode

--- a/eggbox_potential_sampler/eggbox_pes_data_source/tests/__init__.py
+++ b/eggbox_potential_sampler/eggbox_pes_data_source/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/eggbox_potential_sampler/eggbox_pes_data_source/tests/test_data_source.py
+++ b/eggbox_potential_sampler/eggbox_pes_data_source/tests/test_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from unittest import mock

--- a/eggbox_potential_sampler/eggbox_pes_data_source/tests/test_factory.py
+++ b/eggbox_potential_sampler/eggbox_pes_data_source/tests/test_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from eggbox_potential_sampler.eggbox_pes_data_source.data_source\

--- a/eggbox_potential_sampler/eggbox_plugin.py
+++ b/eggbox_potential_sampler/eggbox_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseExtensionPlugin, plugin_id
 
 from .eggbox_pes_data_source.factory import EggboxPESDataSourceFactory

--- a/eggbox_potential_sampler/random_sampling_mco/__init__.py
+++ b/eggbox_potential_sampler/random_sampling_mco/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/eggbox_potential_sampler/random_sampling_mco/mco.py
+++ b/eggbox_potential_sampler/random_sampling_mco/mco.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 import sys
 

--- a/eggbox_potential_sampler/random_sampling_mco/mco_factory.py
+++ b/eggbox_potential_sampler/random_sampling_mco/mco_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseMCOFactory
 
 from enthought_example.example_mco.example_mco_communicator import (

--- a/eggbox_potential_sampler/random_sampling_mco/mco_model.py
+++ b/eggbox_potential_sampler/random_sampling_mco/mco_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Enum
 from force_bdss.api import BaseMCOModel, PositiveInt
 

--- a/eggbox_potential_sampler/random_sampling_mco/parameters.py
+++ b/eggbox_potential_sampler/random_sampling_mco/parameters.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import (
     BaseMCOParameter, BaseMCOParameterFactory
 )

--- a/eggbox_potential_sampler/random_sampling_mco/tests/__init__.py
+++ b/eggbox_potential_sampler/random_sampling_mco/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco.py
+++ b/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from unittest import mock

--- a/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco_factory.py
+++ b/eggbox_potential_sampler/random_sampling_mco/tests/test_random_sampling_mco_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 # from force_bdss.core_plugins import BasicMCOCommunicator

--- a/eggbox_potential_sampler/sampling_data_view/__init__.py
+++ b/eggbox_potential_sampler/sampling_data_view/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
+++ b/eggbox_potential_sampler/sampling_data_view/sampling_data_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 import numpy as np

--- a/eggbox_potential_sampler/sampling_data_view/tests/__init__.py
+++ b/eggbox_potential_sampler/sampling_data_view/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/eggbox_potential_sampler/sampling_data_view/tests/test_sampling_data_view.py
+++ b/eggbox_potential_sampler/sampling_data_view/tests/test_sampling_data_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 try:

--- a/eggbox_potential_sampler/scripts/plot_sigma.py
+++ b/eggbox_potential_sampler/scripts/plot_sigma.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import mock
 import numpy as np
 import matplotlib.pyplot as plt

--- a/eggbox_potential_sampler/tests/__init__.py
+++ b/eggbox_potential_sampler/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/eggbox_potential_sampler/tests/test_eggbox_plugin.py
+++ b/eggbox_potential_sampler/tests/test_eggbox_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import mock
 import sys
 import unittest

--- a/enthought_example/__init__.py
+++ b/enthought_example/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/example_contributed_ui/__init__.py
+++ b/enthought_example/example_contributed_ui/__init__.py
@@ -1,1 +1,4 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from .example_contributed_ui import ExampleContributedUI  # noqa

--- a/enthought_example/example_contributed_ui/example_contributed_ui.py
+++ b/enthought_example/example_contributed_ui/example_contributed_ui.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Float, Int, Property, on_trait_change
 from traitsui.api import Group, Heading, Item
 

--- a/enthought_example/example_contributed_ui/tests/__init__.py
+++ b/enthought_example/example_contributed_ui/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/example_contributed_ui/tests/test_example_contributed_ui.py
+++ b/enthought_example/example_contributed_ui/tests/test_example_contributed_ui.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from traitsui.api import Group

--- a/enthought_example/example_data_source/__init__.py
+++ b/enthought_example/example_data_source/__init__.py
@@ -1,1 +1,4 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from .example_data_source_factory import ExampleDataSourceFactory  # noqa

--- a/enthought_example/example_data_source/example_data_source.py
+++ b/enthought_example/example_data_source/example_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import math
 
 from force_bdss.api import BaseDataSource, DataValue, Slot

--- a/enthought_example/example_data_source/example_data_source_factory.py
+++ b/enthought_example/example_data_source/example_data_source_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSourceFactory
 
 from .example_data_source_model import ExampleDataSourceModel

--- a/enthought_example/example_data_source/example_data_source_model.py
+++ b/enthought_example/example_data_source/example_data_source_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Float, Unicode
 
 from force_bdss.api import BaseDataSourceModel

--- a/enthought_example/example_data_source/tests/__init__.py
+++ b/enthought_example/example_data_source/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/example_data_source/tests/test_example_data_source.py
+++ b/enthought_example/example_data_source/tests/test_example_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from unittest import mock

--- a/enthought_example/example_data_source/tests/test_example_data_source_factory.py
+++ b/enthought_example/example_data_source/tests/test_example_data_source_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from enthought_example.example_data_source.example_data_source import (

--- a/enthought_example/example_data_views/__init__.py
+++ b/enthought_example/example_data_views/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/example_data_views/example_data_view.py
+++ b/enthought_example/example_data_views/example_data_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from pyface.timer.api import do_later
 
 from force_wfmanager.ui.review.plot import BasePlot, ChacoPlot

--- a/enthought_example/example_data_views/tests/__init__.py
+++ b/enthought_example/example_data_views/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/example_data_views/tests/test_example_data_view.py
+++ b/enthought_example/example_data_views/tests/test_example_data_view.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 try:

--- a/enthought_example/example_evaluator/__init__.py
+++ b/enthought_example/example_evaluator/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/example_evaluator/subprocess_workflow.py
+++ b/enthought_example/example_evaluator/subprocess_workflow.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 import os
 import subprocess

--- a/enthought_example/example_evaluator/tests/__init__.py
+++ b/enthought_example/example_evaluator/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/example_evaluator/tests/test_subprocess_workflow.py
+++ b/enthought_example/example_evaluator/tests/test_subprocess_workflow.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import testfixtures
 from unittest import mock, TestCase
 

--- a/enthought_example/example_mco/__init__.py
+++ b/enthought_example/example_mco/__init__.py
@@ -1,1 +1,4 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from .example_mco_factory import ExampleMCOFactory  # noqa

--- a/enthought_example/example_mco/example_mco.py
+++ b/enthought_example/example_mco/example_mco.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import collections
 import itertools
 import logging

--- a/enthought_example/example_mco/example_mco_communicator.py
+++ b/enthought_example/example_mco/example_mco_communicator.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import sys
 
 from force_bdss.api import (

--- a/enthought_example/example_mco/example_mco_factory.py
+++ b/enthought_example/example_mco/example_mco_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseMCOFactory
 
 from .example_mco_communicator import ExampleMCOCommunicator

--- a/enthought_example/example_mco/example_mco_model.py
+++ b/enthought_example/example_mco/example_mco_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseMCOModel
 
 

--- a/enthought_example/example_mco/parameters.py
+++ b/enthought_example/example_mco/parameters.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Float, Range
 from traitsui.api import View, Item
 

--- a/enthought_example/example_mco/tests/__init__.py
+++ b/enthought_example/example_mco/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/example_mco/tests/test_example_mco.py
+++ b/enthought_example/example_mco/tests/test_example_mco.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import mock, TestCase
 
 from traits.api import TraitError

--- a/enthought_example/example_mco/tests/test_example_mco_communicator.py
+++ b/enthought_example/example_mco/tests/test_example_mco_communicator.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from enthought_example.example_plugin import ExamplePlugin

--- a/enthought_example/example_mco/tests/test_example_mco_factory.py
+++ b/enthought_example/example_mco/tests/test_example_mco_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from enthought_example.example_plugin import ExamplePlugin

--- a/enthought_example/example_notification_listener/__init__.py
+++ b/enthought_example/example_notification_listener/__init__.py
@@ -1,1 +1,4 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from .example_notification_listener_factory import ExampleNotificationListenerFactory  # noqa

--- a/enthought_example/example_notification_listener/example_notification_listener.py
+++ b/enthought_example/example_notification_listener/example_notification_listener.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from __future__ import print_function
 
 from force_bdss.api import (

--- a/enthought_example/example_notification_listener/example_notification_listener_factory.py
+++ b/enthought_example/example_notification_listener/example_notification_listener_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseNotificationListenerFactory
 
 from .example_notification_listener import ExampleNotificationListener

--- a/enthought_example/example_notification_listener/example_notification_listener_model.py
+++ b/enthought_example/example_notification_listener/example_notification_listener_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseNotificationListenerModel
 
 

--- a/enthought_example/example_notification_listener/tests/__init__.py
+++ b/enthought_example/example_notification_listener/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/example_notification_listener/tests/test_example_notification_listener.py
+++ b/enthought_example/example_notification_listener/tests/test_example_notification_listener.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 from enthought_example.tests.utils import captured_output
 

--- a/enthought_example/example_notification_listener/tests/test_example_notification_listener_factory.py
+++ b/enthought_example/example_notification_listener/tests/test_example_notification_listener_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from enthought_example.example_plugin import ExamplePlugin

--- a/enthought_example/example_notification_listener/tests/test_example_notification_listener_model.py
+++ b/enthought_example/example_notification_listener/tests/test_example_notification_listener_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from unittest import mock

--- a/enthought_example/example_plugin.py
+++ b/enthought_example/example_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import plugin_id
 from force_bdss.core_plugins.service_offer_plugin import \
     ServiceOfferExtensionPlugin

--- a/enthought_example/example_ui_hooks/__init__.py
+++ b/enthought_example/example_ui_hooks/__init__.py
@@ -1,1 +1,4 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from .example_ui_hooks_factory import ExampleUIHooksFactory  # noqa

--- a/enthought_example/example_ui_hooks/example_ui_hooks_factory.py
+++ b/enthought_example/example_ui_hooks/example_ui_hooks_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseUIHooksFactory
 from .example_ui_hooks_manager import ExampleUIHooksManager
 

--- a/enthought_example/example_ui_hooks/example_ui_hooks_manager.py
+++ b/enthought_example/example_ui_hooks/example_ui_hooks_manager.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseUIHooksManager
 
 

--- a/enthought_example/example_ui_hooks/tests/__init__.py
+++ b/enthought_example/example_ui_hooks/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/example_ui_hooks/tests/test_ui_notification_hooks_factory.py
+++ b/enthought_example/example_ui_hooks/tests/test_ui_notification_hooks_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from enthought_example.example_plugin import ExamplePlugin

--- a/enthought_example/example_ui_hooks/tests/test_ui_notification_hooks_manager.py
+++ b/enthought_example/example_ui_hooks/tests/test_ui_notification_hooks_manager.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 
 from unittest import mock

--- a/enthought_example/tests/__init__.py
+++ b/enthought_example/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/enthought_example/tests/example_workflows/__init__.py
+++ b/enthought_example/tests/example_workflows/__init__.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from os.path import join, dirname, abspath
 
 

--- a/enthought_example/tests/test_example_plugin.py
+++ b/enthought_example/tests/test_example_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import mock
 import sys
 import unittest

--- a/enthought_example/tests/utils.py
+++ b/enthought_example/tests/utils.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import sys
 from contextlib import contextmanager
 from six import StringIO

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import os
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
## Description
Add Enthought open source copyright header to every file.

## Related Issues
https://github.com/force-h2020/force-bdss/pull/351

### Notes
The headers were inserted automatically using PyCharm's Copyright Profile functionality. The only problem is that it ends up creating two blank lines at the end of blank  _init_.py module files, which then don't pass flake8, so the extra line has to be removed manually.

## Changes
Just the header on each file