### PR TITLE
FIX: Builds Travis dependency repos in different directory 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-exclude = build/*,venv/*,doc/source/*,force-bdss/*,force-wfmanager/*
+exclude = build/*,venv/*,doc/source/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ cache:
       - "$HOME/.ccache"
 
 before_install:
+    - cd ${HOME}
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then ccache -s ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=/usr/lib/ccache:${PATH} ; fi
     - export EDM_INSTALLER=${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX}
     - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/${EDM_INSTALLER}
@@ -37,13 +39,14 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools
+    - cd ${HOME}/build/force-h2020/
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss
     - edm run -- python -m ci build-env && edm run -- python -m ci install && popd
     - git clone git://github.com/force-h2020/force-wfmanager.git
     - pushd force-wfmanager
     - edm run -- python -m ci install && popd
-    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sudo apt-get install --yes libglu1-mesa-dev mesa-common-dev; fi
+    - cd force-bdss-plugin-enthought-example
 script:
     - edm run -- python -m ci install
     - edm run -- python -m ci flake8


### PR DESCRIPTION
The PR closes #56 

It builds each BDSS dependency repo (`force-bdss`, `force-wfmanager`) in a separate repository, so the test runner doesn't find the unit tests associated with them during the build.

Consequently, we also no longer need to tell `flake8` to ignore the `force-bdss` and `force-wfmanager` directories.

### Note: 
This should be the preferred way of setting up our Travis jobs throughout all the Force GH repos anyway